### PR TITLE
More linters: adding shellcheck

### DIFF
--- a/.github/workflows/build-test-infrastructure.yml
+++ b/.github/workflows/build-test-infrastructure.yml
@@ -1,4 +1,4 @@
-name: "Test"
+name: "Build test infrastructure"
 on:
   pull_request:
   push:
@@ -10,5 +10,4 @@ jobs:
     - uses: cachix/install-nix-action@v16
       with:
         nix_path: nixpkgs=channel:nixos-22.05
-    - run: ./lint.sh
     - run: tests/build.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: "Lint"
+on:
+  pull_request:
+  push:
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.4.0
+    - uses: cachix/install-nix-action@v16
+      with:
+        nix_path: nixpkgs=channel:nixos-22.05
+    - run: lint/nix.sh
+    - run: lint/shell.sh

--- a/lint.sh
+++ b/lint.sh
@@ -1,7 +1,0 @@
-#! /usr/bin/env nix-shell
-# shellcheck shell=bash
-#! nix-shell -i bash -p nix-linter
-
-set -e
-
-find . -type f -name "*.nix" ! -path "./nix/*" -exec nix-linter {} + && echo "Everything is fine!"

--- a/lint/nix.sh
+++ b/lint/nix.sh
@@ -1,0 +1,10 @@
+#! /usr/bin/env nix-shell
+# shellcheck shell=bash
+#! nix-shell -i bash -p nix-linter
+
+set -e
+
+here=$(dirname "$0")
+root="$here/.."
+
+find "$root" -type f -name "*.nix" ! -path "$root/nix/*" -exec nix-linter {} + && echo "Everything is fine!"

--- a/lint/shell.sh
+++ b/lint/shell.sh
@@ -1,0 +1,10 @@
+#! /usr/bin/env nix-shell
+# shellcheck shell=bash
+#! nix-shell -i bash -p shellcheck
+
+set -e
+
+here=$(dirname "$0")
+root="$here/.."
+
+find "$root" -type f -name "*.sh" -exec shellcheck {} + && echo "Everything is fine!"


### PR DESCRIPTION
To make room to shellcheck I've moved the nix linting scripts to `lint/`.

Linting of bash scripts is done via the amazing [shellcheck](https://www.shellcheck.net).