### PR TITLE
Fix `https://alias` -> `https://main`

### DIFF
--- a/services/website.nix
+++ b/services/website.nix
@@ -16,10 +16,10 @@ let
     alias:
       {
         "${alias}" = {
-          useACMEHost = cfg.domain;
-          locations."/" = {
-            return = "301 https://${cfg.domain}$request_uri";
-          };
+          forceSSL = true;
+          enableACME = true;
+          acmeFallbackHost = cfg.domain;
+          globalRedirect = cfg.domain;
         };
       };
 


### PR DESCRIPTION
The `http://alias` -> `http://main` was working but not if we were to directly load the https variant.

Also there's a [dedicated shortcut for such redirect](https://nixos.org/manual/nixos/stable/options.html#opt-services.nginx.virtualHosts._name_.globalRedirect) in the NixOS module so let's use that directly!