### PR TITLE
Take screenshots at deployment

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "ptitfred",
         "repo": "personal-homepage",
-        "rev": "226b4252344ce9a17a3b5978e030d027ba06b122",
-        "sha256": "145yv62mlcmyfzqs4aii7rl70fpk4828lg9d936pcbnp1v0bvzvj",
+        "rev": "615c042cd1324f2d9123ee2162e752c42a91d940",
+        "sha256": "1g7d2wndkcva26mfki18h88nw148b17phq9wkmlwbm71cznpq9g9",
         "type": "tarball",
-        "url": "https://github.com/ptitfred/personal-homepage/archive/226b4252344ce9a17a3b5978e030d027ba06b122.tar.gz",
+        "url": "https://github.com/ptitfred/personal-homepage/archive/615c042cd1324f2d9123ee2162e752c42a91d940.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,8 @@
+{ pkgs ? import <nixpkgs> {}
+}:
+
+pkgs.mkShell {
+  nativeBuildInputs = [
+    pkgs.morph
+  ];
+}


### PR DESCRIPTION
I wished I could take screenshots in a derivation and simply adjoin the results to the main root directory, but I can't (at least for now) as chromium in a nix sandbox doesn't behave properly.

As this setup uses morph to deploy, scripting are not exactly as straightforward as in the original setup and we got to be a bit imaginative. NixOS relies on systemd so let's use it by creating a oneshot service just to take screenshots. It assumes the website is already served on the target so it's after nginx.service and it takes something like 30 seconds for 10 pages. The good news is that it's done only once (until the service's definition is changed).

The virtualhost definition is extended to serve the directory containing the screenshots on the properly base url. At some point we might be interested in making the base url configurable, but that's really a questionable bonus.