### PR TITLE
Wireguard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+secrets

--- a/configuration/wireguard.nix
+++ b/configuration/wireguard.nix
@@ -1,0 +1,119 @@
+{ config, lib, nodes, ... }:
+
+let otherPeersOpts = with lib; {
+      options = {
+        publicKey = publicKeyOpt;
+
+        allowedIPs = mkOption {
+          example = [ "10.192.122.3/32" "10.192.124.1/24" ];
+          type = with types; listOf str;
+          description = lib.mdDoc ''List of IP (v4 or v6) addresses with CIDR masks from
+          which this peer is allowed to send incoming traffic and to which
+          outgoing traffic for this peer is directed. The catch-all 0.0.0.0/0 may
+          be specified for matching all IPv4 addresses, and ::/0 may be specified
+          for matching all IPv6 addresses.'';
+        };
+      };
+    };
+
+    publicKeyOpt = with lib; mkOption {
+      example = "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=";
+      type = types.str;
+      description = lib.mdDoc "The base64 public key of the peer.";
+    };
+
+in
+{
+  options = with lib; {
+    security.personal-infrastructure.tissue = {
+      publicKey = publicKeyOpt;
+
+      ip = mkOption {
+        type = types.str;
+        example = "10.100.12.34";
+      };
+
+      host = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+      };
+
+      listenIp = mkOption {
+        type = types.str;
+        example = "1.2.3.4";
+      };
+
+      clients = mkOption {
+        type = types.listOf types.str;
+        default = [];
+      };
+
+      other-peers = mkOption {
+        type = types.listOf (types.submodule otherPeersOpts);
+        default = [];
+        example = [ { publicKey = "522Qq1oUTefraap0xh/UdVsGeRGS+H8vS3+QAciQths="; allowedIPs = [ "10.100.12.34/32" ]; } ];
+      };
+
+      joinable = mkOption {
+        type = types.bool;
+        default = false;
+      };
+    };
+  };
+
+  config = {
+    networking =
+      let wg-interface = "tissue";
+          cfg = config.security.personal-infrastructure.tissue;
+          isServer = builtins.length cfg.clients > 0;
+          isClient = builtins.isString cfg.host;
+          server = nodes.${cfg.host}.config.security.personal-infrastructure.tissue.listenIp;
+          serverListenPort = nodes.${cfg.host}.config.networking.wireguard.interfaces.${wg-interface}.listenPort;
+          mkPeer = hostname:
+            let cfg' = nodes.${hostname}.config.security.personal-infrastructure.tissue;
+            in
+              {
+                inherit (cfg') publicKey;
+                allowedIPs = [ "${cfg'.ip}/32" ];
+              };
+      in
+        {
+          nat = lib.modules.mkIf isServer {
+            enable = true;
+            externalInterface = "eth0";
+            internalInterfaces = [ wg-interface ];
+          };
+
+          firewall.allowedUDPPorts = lib.modules.mkIf isServer [ config.networking.wireguard.interfaces.${wg-interface}.listenPort ];
+
+          wireguard.interfaces = {
+            "${wg-interface}" = {
+              ips = [ "${cfg.ip}/24" ];
+              listenPort = lib.modules.mkIf isServer 51820;
+
+              privateKeyFile = config.deployment.secrets.wg-private-key.destination;
+              peers =
+                if isServer
+                then (map mkPeer cfg.clients ++ cfg.other-peers)
+                else lib.modules.mkIf isClient
+                  [
+                    {
+                      publicKey = nodes."${cfg.host}".config.security.personal-infrastructure.tissue.publicKey;
+                      allowedIPs = [ "10.100.0.0/24" ];
+                      endpoint = "${server}:${toString serverListenPort}";
+
+                      persistentKeepalive =
+                        if cfg.joinable
+                        then
+                          # Useful if we want mobile devices to be able to reach this machine behind NAT
+                          25
+                        else null;
+                    }
+                  ];
+            };
+          };
+        };
+
+  };
+
+}

--- a/infrastructure.nix
+++ b/infrastructure.nix
@@ -4,7 +4,13 @@ let
   pkgs = import sources.nixpkgs {};
 in
 
-{ domain, aliases, acme-email, safe-ips, ssh-keys, ... }:
+{ domain
+, aliases
+, acme-email
+, safe-ips
+, ssh-keys
+, ...
+}:
 
 {
   network = {

--- a/infrastructure.nix
+++ b/infrastructure.nix
@@ -2,6 +2,18 @@ let
   # nixos-22.05 as of 2022-10-09, fetched by niv for commodity
   sources = import ./nix/sources.nix;
   pkgs = import sources.nixpkgs {};
+
+  wg-private-key = hostname: {
+    "wg-private-key" = {
+      source = "./secrets/${hostname}/wg-private-key";
+      destination = "/var/secrets/wg-private-key";
+      owner = {
+        user = "root";
+        group = "root";
+      };
+      permissions = "0400";
+    };
+  };
 in
 
 { domain
@@ -9,6 +21,8 @@ in
 , acme-email
 , safe-ips
 , ssh-keys
+, wg-peers
+, resolver
 , ...
 }:
 
@@ -19,26 +33,37 @@ in
   };
 
   dev-01 = { ... }: {
-    deployment = {
-      tags = [ "workstation" ];
-    };
+    deployment.tags = [ "workstation" ];
+    deployment.secrets = wg-private-key "dev-01";
 
     imports = [
       hosts/dev-01/configuration.nix
       configuration/security.nix
+      configuration/wireguard.nix
     ];
 
-    security.personal-infrastructure.root-ssh-keys = [ ssh-keys.local ];
+    security.personal-infrastructure = {
+      root-ssh-keys = [ ssh-keys.local ];
+
+      tissue = {
+        publicKey = "XVJY3lSCjQxHBrrEIDTickR01ox/VKtyiWO6I0nkACQ=";
+        ip = "10.100.0.3";
+        host = "homepage-02";
+        joinable = true;
+      };
+    };
   };
 
   homepage-02 = { ... }: {
     deployment.tags = [ "web" ];
+    deployment.secrets = wg-private-key "homepage-02";
 
     imports = [
       hosts/homepage-02.nix
       morph-utils/monitor-nginx.nix
       services/website.nix
       configuration/security.nix
+      configuration/wireguard.nix
     ];
 
     services.personal-website = {
@@ -51,20 +76,37 @@ in
     security.personal-infrastructure = {
       inherit safe-ips;
       root-ssh-keys = [ ssh-keys.remote ];
+
+      tissue = {
+        publicKey = "WHQ/KKdGP/iuE7ii1lLVq45VKiV4nOdHFSioa1U/XXA=";
+        ip = "10.100.0.1";
+        listenIp = resolver.homepage-02;
+        clients = [ "dev-01" "homepage-03" ];
+        other-peers = wg-peers;
+      };
     };
   };
 
   homepage-03 = { ... }: {
     deployment.tags = [ "infra" ];
+    deployment.secrets = wg-private-key "homepage-03";
 
     imports = [
       hosts/homepage-03.nix
       configuration/security.nix
+      configuration/wireguard.nix
     ];
 
     security.personal-infrastructure = {
       inherit safe-ips;
       root-ssh-keys = [ ssh-keys.remote ];
+
+      tissue = {
+        publicKey = "jOab1ZoQrdbcNSN3qKTOOZ783CdtkCYSnMDXqqIWwXg=";
+        ip = "10.100.0.2";
+        host = "homepage-02";
+        joinable = true;
+      };
     };
   };
 }

--- a/tests/infra.nix
+++ b/tests/infra.nix
@@ -7,4 +7,6 @@ import ../infrastructure.nix {
     local  = builtins.readFile ./key.pub;
     remote = builtins.readFile ./key.pub;
   };
+  wg-peers = [];
+  resolver = { homepage-02 = "127.0.0.1"; };
 }


### PR DESCRIPTION
Configuration helper for wireguard.

Supports both "server" and "client" in [a "Hub and Spoke" setup](https://www.procustodibus.com/blog/2020/10/wireguard-topologies/#hub-and-spoke).

It creates a network interface named "tissue".

It supports other peers (typically mobile devices not managed by morph).