### PR TITLE
Monitoring infrastructure

### DIFF
--- a/infrastructure.nix
+++ b/infrastructure.nix
@@ -63,6 +63,7 @@ in
     imports = [
       hosts/homepage-02.nix
       morph-utils/monitor-nginx.nix
+      services/monitoring.nix
       services/website.nix
       configuration/security.nix
       configuration/wireguard.nix
@@ -97,6 +98,7 @@ in
       hosts/homepage-03.nix
       configuration/security.nix
       configuration/wireguard.nix
+      services/monitoring.nix
     ];
 
     security.personal-infrastructure = {

--- a/services/monitoring.nix
+++ b/services/monitoring.nix
@@ -1,0 +1,38 @@
+{ config, ... }:
+
+{
+  services.grafana = {
+    enable = true;
+    port = 2342;
+    provision = {
+      datasources = [
+        {
+          name = "Prometheus";
+          type = "prometheus";
+          url = "http://localhost:${toString config.services.prometheus.port}";
+        }
+      ];
+    };
+  };
+
+  services.prometheus = {
+    enable = true;
+    exporters = {
+      node = {
+        enable = true;
+        enabledCollectors = [ "systemd" ];
+      };
+    };
+
+    scrapeConfigs = [
+      {
+        job_name = "chrysalis";
+        static_configs = [{
+          targets = [ "127.0.0.1:${toString config.services.prometheus.exporters.node.port}" ];
+        }];
+      }
+    ];
+  };
+
+  networking.firewall.interfaces."tissue".allowedTCPPorts = [ config.services.grafana.port ];
+}


### PR DESCRIPTION
⚠️ Very drafty, not that useful for now.

Having it accessible via the wireguard network is a start, but configuration is not managed properly and no backup of manual configuration is done yet.

Another important part of the settings would be to have a single grafana somewhere, aggregating data from the various prometheus nodes. This PR deploys grafana everywhere the module is imported.