### PR TITLE
nginx: Add support of Brotli

### DIFF
--- a/services/brotlify.nix
+++ b/services/brotlify.nix
@@ -1,0 +1,29 @@
+{ stdenvNoCC
+, lib
+, brotli }:
+{ src
+, fileExtensions ? [
+  "html" "js" "css" "json" "txt" "ttf" "ico" "wasm"
+]}:
+let
+  findQuery = lib.flatten (lib.intersperse "-o"
+    (map (ext: [ "-iname" (lib.escapeShellArg "*.${ext}") ]) fileExtensions));
+in stdenvNoCC.mkDerivation {
+  inherit src;
+  # inherit (src) version;
+  name = "${src.name}-brotlified";
+
+  nativeBuildInputs = [
+    brotli
+  ];
+
+  buildPhase = ''
+    find . -type f,l \( \
+      ${lib.concatStringsSep " " findQuery} \
+      \) -print0 | xargs -0 -P $NIX_BUILD_CORES -I{} brotli -vZk {}
+  '';
+
+  installPhase = ''
+    cp -r . $out
+  '';
+}

--- a/services/website.nix
+++ b/services/website.nix
@@ -5,6 +5,7 @@ with lib;
 let
   cfg = config.services.personal-website;
   sources = import ../nix/sources.nix;
+  brotlify = pkgs.callPackage ./brotlify.nix { };
 
   baseUrl = "https://${cfg.domain}";
 
@@ -35,7 +36,8 @@ let
         enableACME = true;
 
         locations."/" = {
-          inherit (website.nginx) root extraConfig;
+          root = brotlify { src = website.nginx.root; };
+          inherit (website.nginx) extraConfig;
         };
 
         locations."/${screenshotsSubdirectory}/" = {
@@ -77,6 +79,19 @@ in
       services.nginx = {
         enable = true;
         inherit virtualHosts;
+        additionalModules = [ pkgs.nginxModules.brotli ];
+        recommendedGzipSettings = true;
+        recommendedProxySettings = true;
+        appendHttpConfig = ''
+          brotli on;
+          brotli_comp_level 6;
+          brotli_static on;
+          brotli_types application/atom+xml application/javascript application/json application/rss+xml
+                 application/vnd.ms-fontobject application/x-font-opentype application/x-font-truetype
+                 application/x-font-ttf application/x-javascript application/xhtml+xml application/xml
+                 font/eot font/opentype font/otf font/truetype image/svg+xml image/vnd.microsoft.icon
+                 image/x-icon image/x-win-bitmap text/css text/javascript text/plain text/xml;
+        '';
       };
 
       networking.firewall.allowedTCPPorts = [ 80 443 ];


### PR DESCRIPTION
Totally inspired by https://dee.underscore.world/blog/brotlifying-nginx/ with some minor modifications:

- source derivation doesn't expose a `pname` attribute in my setup
- the brotlify derivation also list symlinks as I already aggregate multiple source derivations upfront.