### PR TITLE
The capable workstation serves nix-store on the private network

### DIFF
--- a/configuration/nix-serve.nix
+++ b/configuration/nix-serve.nix
@@ -1,0 +1,17 @@
+let
+  sources = import ../nix/sources.nix;
+  nix-serve-ng = import sources.nix-serve-ng;
+in
+
+{ config, ... }:
+{
+  imports = [ nix-serve-ng.nixosModules.default ];
+
+  services.nix-serve = {
+    enable = true;
+    bindAddress = config.security.personal-infrastructure.tissue.ip;
+    secretKeyFile = config.deployment.secrets.nix-serve-private-key.destination;
+  };
+
+  networking.firewall.interfaces."tissue".allowedTCPPorts = [ config.services.nix-serve.port ];
+}

--- a/hosts/dev-01/configuration.nix
+++ b/hosts/dev-01/configuration.nix
@@ -124,6 +124,8 @@
   # Enable the OpenSSH daemon.
   services.openssh.enable = true;
 
+  programs.ssh.startAgent = true;
+
   services.dbus.packages = with pkgs; [ dconf ];
   programs.dconf.enable = true;
 

--- a/infrastructure.nix
+++ b/infrastructure.nix
@@ -52,8 +52,6 @@ in
         joinable = true;
       };
     };
-
-    programs.ssh.startAgent = true;
   };
 
   homepage-02 = { ... }: {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,4 +1,16 @@
 {
+    "nix-serve-ng": {
+        "branch": "main",
+        "description": "A drop-in replacement for nix-serve that is faster and more reliable",
+        "homepage": "",
+        "owner": "aristanetworks",
+        "repo": "nix-serve-ng",
+        "rev": "b6cabad4343edb0247eeac29bc35920de8d08785",
+        "sha256": "11b8n8kvk468fnwsfqhmc0cygw80q4vcywdywl7rk1xm4d454g3p",
+        "type": "tarball",
+        "url": "https://github.com/aristanetworks/nix-serve-ng/archive/b6cabad4343edb0247eeac29bc35920de8d08785.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "nixpkgs": {
         "branch": "nixos-22.05",
         "description": "Nix Packages collection",


### PR DESCRIPTION
This is much more an exercise than anything as currently everything is built from the `dev-01` host and so no need to use private cache. It could help for a laptop or more transient weak machines to fetch build artifacts at some point.

Another interesting thing to test would be to let the `dev-01` host behave like a remote builder for others. To do in a follow-up PR I guess.