### PR TITLE
WireGuard: Aliases for all known hosts in tissue

### DIFF
--- a/configuration/personal-infrastructure/wireguard.nix
+++ b/configuration/personal-infrastructure/wireguard.nix
@@ -76,8 +76,19 @@ in
                 inherit (cfg') publicKey;
                 allowedIPs = [ "${cfg'.ip}/32" ];
               };
+
+          mkHostAlias = hostname:
+            let ip' = nodes.${hostname}.config.personal-infrastructure.tissue.ip;
+                alias = "${hostname}.${wg-interface}";
+            in _: { "${ip'}" = alias; };
+
+          collectHostAliases = lib.attrsets.foldAttrs (n: a: [n] ++ a) [];
+
+          hostAliases = lib.attrsets.mapAttrsToList mkHostAlias nodes;
       in
         {
+          hosts = collectHostAliases hostAliases;
+
           nat = lib.modules.mkIf isServer {
             enable = true;
             externalInterface = "eth0";


### PR DESCRIPTION
Example of `/etc/hosts` file for host dev-01:

```
127.0.0.1 localhost
::1 localhost
10.100.0.1 homepage-02.tissue
10.100.0.2 homepage-03.tissue
10.100.0.3 dev-01.tissue
127.0.0.2 dev-01
::1 dev-01
```

Lines 3, 4 and 5 are generated by the change introduced in this PR.

This is handy to reference hosts on the Wireguard network without risking to use any public interface, for instance by pinging.