### PR TITLE
Matomo

### DIFF
--- a/configuration/personal-infrastructure/default.nix
+++ b/configuration/personal-infrastructure/default.nix
@@ -4,8 +4,9 @@
   imports = [
     ./acme.nix
     ./fail2ban.nix
+    ./matomo.nix
+    ./nix-cache.nix
     ./security.nix
     ./wireguard.nix
-    ./nix-cache.nix
   ];
 }

--- a/configuration/personal-infrastructure/matomo.nix
+++ b/configuration/personal-infrastructure/matomo.nix
@@ -1,0 +1,49 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.personal-infrastructure.matomo;
+in
+{
+  options.personal-infrastructure.matomo = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+    };
+
+    hostname = mkOption {
+      type = types.str;
+      example = "matomo.example.org";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.matomo = {
+      enable = true;
+      nginx = {};
+      inherit (cfg) hostname;
+    };
+
+    services.mysql = {
+      enable = true;
+      package = pkgs.mariadb;
+
+      ensureUsers = [
+        {
+          name = "kiwi";
+          ensurePermissions = {
+            "database.matomo" = "ALL PRIVILEGES";
+          };
+        }
+        {
+          name = "backup";
+          ensurePermissions = {
+            "*.*" = "SELECT, LOCK TABLES";
+          };
+        }
+      ];
+
+      ensureDatabases = [ "matomo" ];
+    };
+  };
+}

--- a/infrastructure.nix
+++ b/infrastructure.nix
@@ -26,6 +26,7 @@ in
 , ssh-keys
 , wg-peers
 , resolver
+, matomo-hostname
 , ...
 }:
 
@@ -87,6 +88,11 @@ in
         inherit safe-ips;
       };
 
+      matomo = {
+        enable = true;
+        hostname = matomo-hostname;
+      };
+
       root-ssh-keys = [ ssh-keys.remote ];
 
       tissue = {
@@ -97,6 +103,7 @@ in
         other-peers = wg-peers;
       };
     };
+
   };
 
   homepage-03 = { ... }: {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "ptitfred",
         "repo": "personal-homepage",
-        "rev": "8546be2dc81e6bb5d1aefba432fc44cb8f3eb73e",
-        "sha256": "18fy0lkp9im2al6rn6z01z8x435jv0w8wrxif9frf76crsm5rnq4",
+        "rev": "89c2f8d4b32d3faac7801fd7b2662544d5f767cc",
+        "sha256": "03nc8y6hib9cb4ldfsqxj3g1ps1ch8izhzyfrrnp8gcfpi93j6vs",
         "type": "tarball",
-        "url": "https://github.com/ptitfred/personal-homepage/archive/8546be2dc81e6bb5d1aefba432fc44cb8f3eb73e.tar.gz",
+        "url": "https://github.com/ptitfred/personal-homepage/archive/89c2f8d4b32d3faac7801fd7b2662544d5f767cc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -3,6 +3,6 @@
 
 pkgs.mkShell {
   nativeBuildInputs = [
-    pkgs.morph
+    pkgs.morph pkgs.pwgen
   ];
 }

--- a/tests/infra.nix
+++ b/tests/infra.nix
@@ -9,4 +9,5 @@ import ../infrastructure.nix {
   };
   wg-peers = [];
   resolver = { homepage-02 = "127.0.0.1"; };
+  matomo-hostname = "matomo.localhost";
 }


### PR DESCRIPTION
MySQL setup requires user's password change and grants via the mysql prompt from root. This is not automagically configured by nix.

Matomo configuration is also manually finalized via their online wizard (sic) and notably requires the mysql user and password.

This is weak and configuration isn't backed up. But I'll keep it that way as it's not a critical part of the whole infrastructure.