### PR TITLE
Nginx: Brotli configuration reusable

### DIFF
--- a/services/brotli.nix
+++ b/services/brotli.nix
@@ -1,0 +1,30 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  enabled = config.services.nginx.enable && config.services.nginx.brotliSupport;
+in
+  {
+    options.services.nginx.brotliSupport = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        If true, nginx will be configured to support Brotli compression.
+      '';
+    };
+
+    config = mkIf enabled {
+      services.nginx.additionalModules = [ pkgs.nginxModules.brotli ];
+      services.nginx.appendHttpConfig = ''
+          brotli on;
+          brotli_comp_level 6;
+          brotli_static on;
+          brotli_types application/atom+xml application/javascript application/json application/rss+xml
+                 application/vnd.ms-fontobject application/x-font-opentype application/x-font-truetype
+                 application/x-font-ttf application/x-javascript application/xhtml+xml application/xml
+                 font/eot font/opentype font/otf font/truetype image/svg+xml image/vnd.microsoft.icon
+                 image/x-icon image/x-win-bitmap text/css text/javascript text/plain text/xml;
+        '';
+    };
+  }

--- a/services/freelancing.nix
+++ b/services/freelancing.nix
@@ -35,6 +35,10 @@ let
   virtualHosts = foldr mkRedirect hostingHost cfg.aliases;
 in
   {
+    imports = [
+      ./brotli.nix
+    ];
+
     options.services.freelancing = {
       enable = mkOption {
         type = types.bool;
@@ -82,6 +86,7 @@ in
         inherit virtualHosts;
         recommendedGzipSettings = true;
         recommendedProxySettings = true;
+        brotliSupport = true;
       };
 
       networking.firewall.allowedTCPPorts = [ 80 443 ];

--- a/services/website.nix
+++ b/services/website.nix
@@ -50,6 +50,10 @@ let
   virtualHosts = foldr mkRedirect hostingHost cfg.aliases;
 in
   {
+    imports = [
+      ./brotli.nix
+    ];
+
     options.services.personal-website = {
       enable = mkOption {
         type = types.bool;
@@ -79,19 +83,9 @@ in
       services.nginx = {
         enable = true;
         inherit virtualHosts;
-        additionalModules = [ pkgs.nginxModules.brotli ];
         recommendedGzipSettings = true;
         recommendedProxySettings = true;
-        appendHttpConfig = ''
-          brotli on;
-          brotli_comp_level 6;
-          brotli_static on;
-          brotli_types application/atom+xml application/javascript application/json application/rss+xml
-                 application/vnd.ms-fontobject application/x-font-opentype application/x-font-truetype
-                 application/x-font-ttf application/x-javascript application/xhtml+xml application/xml
-                 font/eot font/opentype font/otf font/truetype image/svg+xml image/vnd.microsoft.icon
-                 image/x-icon image/x-win-bitmap text/css text/javascript text/plain text/xml;
-        '';
+        brotliSupport = true;
       };
 
       networking.firewall.allowedTCPPorts = [ 80 443 ];


### PR DESCRIPTION
This let us have multiple configurations of Nginx requiring Brotli separatly.

If you duplicate it in each setup, Nginx will complain at boot that some configuration attributes are duplicated. We don't want that, do we?