### PR TITLE
Tooling: download remote closure to compare

### DIFF
--- a/pending-diff.sh
+++ b/pending-diff.sh
@@ -2,4 +2,6 @@
 # shellcheck shell=bash
 #! nix-shell -i bash -p morph nvd
 
-nvd diff "$(ssh "$1" readlink -f /nix/var/nix/profiles/system)" "$(morph build --on="$1" ./test-infra.nix)/$1"
+remoteSystem="$(ssh "$1" readlink -f /nix/var/nix/profiles/system)"
+nix-copy-closure --from "$1" "$remoteSystem"
+nvd diff "$remoteSystem" "$(morph build --on="$1" ./test-infra.nix)/$1"


### PR DESCRIPTION
It happens we GC the store locally or a given host has been deployed from elsewhere and we don't have the whole closure for a remote system and therefore the script comparing what's changed in the meantime wasn't always able to check.

This patch make sure we have it locally first. Of course it's not ideal for the local store size.