### PR TITLE
Bump dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -88,7 +88,10 @@
     },
     "gitignore": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": [
+          "personal-homepage",
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1660459072,
@@ -106,7 +109,9 @@
     },
     "home-manager": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1687871164,
@@ -118,15 +123,15 @@
       },
       "original": {
         "owner": "nix-community",
+        "ref": "release-23.05",
         "repo": "home-manager",
-        "rev": "07c347bb50994691d7b0095f45ebd8838cf6bc38",
         "type": "github"
       }
     },
     "nix-serve-ng": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "utils": "utils"
       },
       "locked": {
@@ -140,27 +145,10 @@
       "original": {
         "owner": "aristanetworks",
         "repo": "nix-serve-ng",
-        "rev": "f3931b8120b1ca663da280e11659c745e2e9ad1b",
         "type": "github"
       }
     },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1687466461,
-        "narHash": "sha256-oupXI7g7RPzlpGUfAu1xG4KBK53GrZH8/xeKgKDB4+Q=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "ecb441f22067ba1d6312f4932a7c64efa8d19a7b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-23.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
       "locked": {
         "lastModified": 1688403656,
         "narHash": "sha256-zmNai3dKWUCKpKubPWsEJ1Q7od96KebWVDJNCnk+fr0=",
@@ -176,37 +164,23 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1690148897,
+        "narHash": "sha256-l/j/AX1d2K79EWslwgWR2+htkzCbtjKZsS5NbWXnhz4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ac1acba43b2f9db073943ff5ed883ce7e8a40a2c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1689885880,
-        "narHash": "sha256-2ikAcvHKkKh8J/eUrwMA+wy1poscC+oL1RkN1V3RmT8=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "fa793b06f56896b7d1909e4b69977c7bf842b2f0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "fa793b06f56896b7d1909e4b69977c7bf842b2f0",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1632846328,
-        "narHash": "sha256-sFi6YtlGK30TBB9o6CW7LG9mYHkgtKeWbSLAjjrNTX0=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "2b71ddd869ad592510553d09fe89c9709fa26b2b",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_5": {
       "locked": {
         "lastModified": 1689956312,
         "narHash": "sha256-NV9yamMhE5jgz+ZSM2IgXeYqOvmGIbIIJ+AFIhfD7Ek=",
@@ -226,22 +200,21 @@
       "inputs": {
         "flake-compat": "flake-compat_3",
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_3",
         "posix-toolbox": "posix-toolbox",
         "previous": "previous"
       },
       "locked": {
-        "lastModified": 1690139392,
-        "narHash": "sha256-dFM/6aUScR4nBJqGxkM4eCl9tGiNtJgJt+u/I9ltffY=",
+        "lastModified": 1690192769,
+        "narHash": "sha256-Q+miQBMnCKbYvkVzVtwZA+3nzsLqk+kakWjwzEFjAF8=",
         "owner": "ptitfred",
         "repo": "personal-homepage",
-        "rev": "69d49f9c14ef0868f0e23189178c08b4aece8bc1",
+        "rev": "3f61b7ecdf286d43480602c5ccc79e1576668b94",
         "type": "github"
       },
       "original": {
         "owner": "ptitfred",
         "repo": "personal-homepage",
-        "rev": "69d49f9c14ef0868f0e23189178c08b4aece8bc1",
         "type": "github"
       }
     },
@@ -298,7 +271,7 @@
         "colmena": "colmena",
         "home-manager": "home-manager",
         "nix-serve-ng": "nix-serve-ng",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_2",
         "personal-homepage": "personal-homepage",
         "previous": "previous_2"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,17 +2,18 @@
   description = "Personal infrastructure";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?rev=fa793b06f56896b7d1909e4b69977c7bf842b2f0";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
     previous.url = "github:nixos/nixpkgs/nixos-22.11";
 
     colmena.url = "github:zhaofengli/colmena";
     colmena.inputs.nixpkgs.follows = "nixpkgs";
 
-    personal-homepage.url = "github:ptitfred/personal-homepage?rev=69d49f9c14ef0868f0e23189178c08b4aece8bc1";
+    personal-homepage.url = "github:ptitfred/personal-homepage";
 
-    nix-serve-ng.url = "github:aristanetworks/nix-serve-ng?rev=f3931b8120b1ca663da280e11659c745e2e9ad1b";
+    nix-serve-ng.url = "github:aristanetworks/nix-serve-ng";
 
-    home-manager.url = "github:nix-community/home-manager?rev=07c347bb50994691d7b0095f45ebd8838cf6bc38";
+    home-manager.url = "github:nix-community/home-manager/release-23.05";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = inputs@{ nixpkgs, previous, ... }:


### PR DESCRIPTION
Now that it has been deployed with the same dependencies as those coming from niv, let's bump everything via a good ol' `nix flake update`.