### PR TITLE
PostgreSQL support

### DIFF
--- a/configuration/personal-infrastructure/default.nix
+++ b/configuration/personal-infrastructure/default.nix
@@ -8,5 +8,6 @@
     ./nix-cache.nix
     ./security.nix
     ./wireguard.nix
+    ./postgresql.nix
   ];
 }

--- a/configuration/personal-infrastructure/postgresql.nix
+++ b/configuration/personal-infrastructure/postgresql.nix
@@ -1,0 +1,87 @@
+{ config, lib, pkgs, ... }:
+
+let cfg = config.personal-infrastructure.postgresql;
+    users = cfg.users;
+
+    options = {
+      enable = lib.mkEnableOption "Postgresql service with user & db provisioning";
+      users = lib.mkOption {
+        type = lib.types.attrsOf userType;
+        default = {};
+      };
+    };
+
+    userType = lib.types.submodule {
+      options = {
+        databases = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          description = "databases for this user. The databases will be created.";
+          default = [];
+        };
+
+        superuser = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+        };
+
+        initialPassword = lib.mkOption {
+          type = lib.types.str;
+          description = "Password hashed with scram-sha-256.";
+        };
+      };
+    };
+
+    service = {
+      enable = true;
+      inherit authentication ensureDatabases ensureUsers;
+    };
+
+    authentication = lib.strings.concatMapStrings authenticate (builtins.attrNames users);
+
+    authenticate = userName: ''
+      local all ${userName} scram-sha-256
+    '';
+
+    ensureDatabases = lib.lists.unique (lib.lists.concatMap (u: u.databases) (builtins.attrValues users));
+
+    ensureUsers = lib.attrsets.mapAttrsToList buildUser users;
+
+    buildUser = name: def: {
+      inherit name;
+      ensurePermissions = ensurePermissions def;
+      ensureClauses     = ensureClauses     def;
+    };
+
+    ensurePermissions = def: lib.lists.foldr buildPermission {} def.databases;
+
+    buildPermission = database: acc:
+      acc // {
+        "DATABASE ${database}" = "ALL PRIVILEGES";
+      };
+
+    ensureClauses = def: {
+      inherit (def) superuser;
+      createrole = def.superuser;
+      createdb   = def.superuser;
+    };
+
+    setPasswords = ''
+      $PSQL -tAf ${setPasswordsSQLFile}
+    '';
+
+    setPasswordsSQLFile =
+      pkgs.writeText "set-passwords.sql"
+      (lib.strings.concatStrings (lib.attrsets.mapAttrsToList mkAlterRoleStatement users));
+
+    mkAlterRoleStatement = name: def: ''
+      ALTER ROLE "${name}" WITH PASSWORD '${def.initialPassword}';
+    '';
+in
+{
+  options.personal-infrastructure.postgresql = options;
+
+  config = lib.mkIf cfg.enable {
+    services.postgresql = service;
+    systemd.services.postgresql.postStart = setPasswords;
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -451,7 +451,24 @@
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_3",
         "personal-homepage": "personal-homepage",
-        "previous": "previous_3"
+        "previous": "previous_3",
+        "scram-sha-256": "scram-sha-256"
+      }
+    },
+    "scram-sha-256": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1670309617,
+        "narHash": "sha256-pD4zhLvmhIbIxer6UlP+TBZigym5F9cVFHQaWCtSFuA=",
+        "owner": "supercaracal",
+        "repo": "scram-sha-256",
+        "rev": "675ce0375e96a22723eb0551eb7ed4676672155a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "supercaracal",
+        "repo": "scram-sha-256",
+        "type": "github"
       }
     },
     "spago2nix": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,11 @@
     nixos-hardware.url = "github:nixos/nixos-hardware";
 
     home-manager-base.url = "github:ptitfred/home-manager";
+
+    scram-sha-256 = {
+      url = "github:supercaracal/scram-sha-256";
+      flake = false;
+    };
   };
 
   outputs = inputs@{ nixpkgs, previous, ... }:
@@ -39,10 +44,17 @@
           let mkNode = name: { inherit name; path = test-infra.${name}; };
               nodes = lib.nodesFromHive test-hive;
            in pkgs.linkFarm test-hive.meta.description (map mkNode nodes);
+
+        scram-sha-256 = pkgs.buildGoModule {
+          name = "scram-sha-256";
+          src = inputs.scram-sha-256;
+          vendorSha256 = "sha256-qNJSCLMPdWgK/eFPmaYBcgH3P6jHBqQeU4gR6kE/+AE=";
+        };
+
      in {
           devShells.${system}.default = pkgs.mkShell { buildInputs = [ inputs.colmena.packages.${system}.colmena pkgs.pwgen ]; };
 
-          packages.${system} = tools;
+          packages.${system} = tools // { inherit scram-sha-256; };
 
           inherit lib colmena tests test-hive;
         };


### PR DESCRIPTION
```nix
{ ... }:

{
  personal-infrastructure.postgresql = {
    enable = true;
    available-on-tissue = true;
    users = {
      user1 = {
        databases = [ "db_user1" "db_service1" ];
        initialPassword = "SCRAM-SHA-256$4096:DoZ1ed1syIYfoKWgDdHXbQ==$tf8f8l10T/nt7v4rRl0xM3UoXltOD+ddO+oSwMHmbVQ=:YmxZ7hPnJcrQ3g0F3KEwrYwQWOrN2MQvH4aFjmQrW3M=";
        superuser = true;
      };
      service1 = {
        databases = [ "db_service1" ];
        initialPassword = "SCRAM-SHA-256$4096:z+/dX1i1UxgegJd1PCeSYA==$mjdoWKH53eKVtC8KfnYg3tN0DThzEuHAOLAEQT1zZ+A=:6v6roQOItHDE0vHnkv7XDc2YKppebiwPoEk0wsFB/b0=";
      };
    };
  };
}
```

2 databases will be created (if missing):
- `db_user1`
- `db_service1`

2 users will be created (if missing):
- `user1` ; this one will have access to both databases
- `service1` ; this one only has access to its own database

`user1` can also create databases and roles as a super-user.

Both users are given a password, hashed in [SCRAM-SHA-256](https://www.postgresql.org/docs/current/auth-password.html). This PR also packages [this tool](https://github.com/supercaracal/scram-sha-256) to forge such hashes.

The server is made accessible locally and on the tissue interface (wireguard).