### PR TITLE
Upgrade to 23.11

### DIFF
--- a/nixos/hardware/gandicloud.nix
+++ b/nixos/hardware/gandicloud.nix
@@ -16,5 +16,8 @@
       wantedBy = [ "multi-user.target" ];
       serviceConfig.Restart = "always";
     };
+
+    # This is required since 23.11 ; I'm not sure why. Maybe Gandi changed something in their VMs.
+    boot.loader.grub.device = lib.mkForce "nodev";
   };
 }


### PR DESCRIPTION
When deploying to servers, some changes were needed:
- The postgresql service doesn't support `ensurePermissions` anymore. It's fixed by implementing a custom SQL script post boot/reboot.
- I had to patch the Grub config for Gandi VPS.