### PR TITLE
Personal website: other redirections (shortcuts)

### DIFF
--- a/hive/homepage-02/system.nix
+++ b/hive/homepage-02/system.nix
@@ -16,7 +16,7 @@
 
   services.personal-website = {
     enable = true;
-    inherit (infrastructure) domain aliases;
+    inherit (infrastructure) domain aliases redirections;
   };
 
   personal-infrastructure = {

--- a/tests/infra.nix
+++ b/tests/infra.nix
@@ -2,6 +2,12 @@ let infrastructure =
       {
         domain = "test.localhost";
         aliases = [ "localhost" "test2.localhost" ];
+        redirections = [
+          {
+            path = "/example";
+            target = "https://example.org";
+          }
+        ];
         acme-email = "acme@localhost";
         safe-ips = [ "1.1.1.1" ];
         ssh-keys = {


### PR DESCRIPTION
This PR let us (well me) configure extra redirections to append to the `extraConfig`. This would be mostly useful for short-lived or private redirections.