### PR TITLE
matomo: upgrade to 5.1.2

### DIFF
--- a/nixos/personal-infrastructure/matomo.nix
+++ b/nixos/personal-infrastructure/matomo.nix
@@ -3,6 +3,19 @@
 with lib;
 
 let cfg = config.personal-infrastructure.matomo;
+
+    version = "5.1.2";
+    hash = "sha256-6kR6OOyqwQfV+pRqHO+VMLM1eZQb0om65EilAnIlW9U=";
+
+    # matomo_5 in nixpkgs is at 5.1.1 as of this commit
+    package = pkgs.matomo_5.overrideAttrs {
+      name = "matomo_5-${version}";
+      inherit version;
+      src = pkgs.fetchurl {
+        url = "https://builds.matomo.org/matomo-${version}.tar.gz";
+        inherit hash;
+      };
+    };
 in
 {
   options.personal-infrastructure.matomo = {
@@ -20,6 +33,7 @@ in
   config = mkIf cfg.enable {
     services.matomo = {
       enable = true;
+      inherit package;
       nginx = {};
       inherit (cfg) hostname;
     };


### PR DESCRIPTION
Major upgrade : 4.16.1 -> 5.1.2

I have no idea how upgrade will roll. I expect the current setup to break.

- [x] review [release notes](https://developer.matomo.org/changelog):
  - 5.0.0 breaks a lot of things related to plugins. I don't use any third-party plugin so I _should_ be fine
  - 5.1.0 is similar to 5.0.0 but smaller. Same conclusion. 
- [ ] ~prepare some migration scripts?~
- [x] test it