### PR TITLE
services.postgresql.port deprecated

### DIFF
--- a/nixos/personal-infrastructure/postgresql.nix
+++ b/nixos/personal-infrastructure/postgresql.nix
@@ -124,6 +124,6 @@ in
     services.postgresql = service;
     systemd.services.postgresql.postStart = setPasswords;
     networking.firewall.interfaces."tissue".allowedTCPPorts =
-      lib.mkIf cfg.available-on-tissue [ config.services.postgresql.port ];
+      lib.mkIf cfg.available-on-tissue [ config.services.postgresql.settings.port ];
   };
 }


### PR DESCRIPTION
Moved to `services.postgresql.settings.port` since https://github.com/NixOS/nixpkgs/commit/5142b7afa88db6ccec229521ad96df4419f6abe4.