### PR TITLE
flake-updater: more accurate default timer

### DIFF
--- a/home/automation/flake-updater/default.nix
+++ b/home/automation/flake-updater/default.nix
@@ -35,7 +35,7 @@ let script = pkgs.callPackage ./package.nix {};
         };
 
         interval = lib.mkOption {
-          default = "24h";
+          default = "daily";
           type = lib.types.str;
           example = "12h";
           description = ''
@@ -79,6 +79,7 @@ let script = pkgs.callPackage ./package.nix {};
       value = {
         Unit.Description = mkServiceDescription name;
         Timer.OnUnitActiveSec = options.interval;
+        Timer.Persistent = true;
         Install.WantedBy = [ "timers.target" ];
       };
     };


### PR DESCRIPTION
Made persistent (to handle laptop being shutdown), and better default.