### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -362,11 +362,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1729742320,
-        "narHash": "sha256-u3Of8xRkN//me8PU+RucKA59/6RNy4B2jcGAF36P4jI=",
+        "lastModified": 1730161780,
+        "narHash": "sha256-z5ILcmwMtiCoHTXS1KsQWqigO7HJO8sbyK7f7wn9F/E=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "e8a2f6d5513fe7b7d15701b2d05404ffdc3b6dda",
+        "rev": "07d15e8990d5d86a631641b4c429bc0a7400cfb8",
         "type": "github"
       },
       "original": {
@@ -409,11 +409,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1729691686,
-        "narHash": "sha256-BAuPWW+9fa1moZTU+jFh+1cUtmsuF8asgzFwejM4wac=",
+        "lastModified": 1730137625,
+        "narHash": "sha256-9z8oOgFZiaguj+bbi3k4QhAD6JabWrnv7fscC/mt0KE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "32e940c7c420600ef0d1ef396dc63b04ee9cad37",
+        "rev": "64b80bfb316b57cdb8919a9110ef63393d74382a",
         "type": "github"
       },
       "original": {
@@ -441,11 +441,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1729691686,
-        "narHash": "sha256-BAuPWW+9fa1moZTU+jFh+1cUtmsuF8asgzFwejM4wac=",
+        "lastModified": 1730137625,
+        "narHash": "sha256-9z8oOgFZiaguj+bbi3k4QhAD6JabWrnv7fscC/mt0KE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "32e940c7c420600ef0d1ef396dc63b04ee9cad37",
+        "rev": "64b80bfb316b57cdb8919a9110ef63393d74382a",
         "type": "github"
       },
       "original": {
@@ -550,11 +550,11 @@
         "posix-toolbox": "posix-toolbox"
       },
       "locked": {
-        "lastModified": 1729846045,
-        "narHash": "sha256-pIEoSLLx7cmxFtBqouDP8WOXYKBN/+sWVfelGPgzStI=",
+        "lastModified": 1730032537,
+        "narHash": "sha256-zzfniPNVsdCeXvGfdNB1AUNGCVukwv2l/2guYg3kF24=",
         "owner": "ptitfred",
         "repo": "personal-homepage",
-        "rev": "d6efe39fdfdeecca216430fcff99864e50c30d16",
+        "rev": "37f293151412094171e1b50d4b234f8478613ba5",
         "type": "github"
       },
       "original": {
@@ -573,11 +573,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors_2"
       },
       "locked": {
-        "lastModified": 1729846061,
-        "narHash": "sha256-E9kD8L39xKMIKY1lhCGIwZ6SjQbKVfc+tn/Oh35tZGU=",
+        "lastModified": 1730219815,
+        "narHash": "sha256-QMSCDZ5TLFnSxd4ia1IymuaebNNAdU+besKfwZj59VQ=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "c1765143f3d8df604d5c04fdef78f62e98d7fbec",
+        "rev": "658ff2ba30c4f760c2cb9d4e95c6e93e38c4ef56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'nixos-hardware':
    'github:nixos/nixos-hardware/e8a2f6d5513fe7b7d15701b2d05404ffdc3b6dda' (2024-10-24)
  → 'github:nixos/nixos-hardware/07d15e8990d5d86a631641b4c429bc0a7400cfb8' (2024-10-29)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/32e940c7c420600ef0d1ef396dc63b04ee9cad37' (2024-10-23)
  → 'github:nixos/nixpkgs/64b80bfb316b57cdb8919a9110ef63393d74382a' (2024-10-28)
• Updated input 'ptitfred-personal-homepage':
    'github:ptitfred/personal-homepage/d6efe39fdfdeecca216430fcff99864e50c30d16' (2024-10-25)
  → 'github:ptitfred/personal-homepage/37f293151412094171e1b50d4b234f8478613ba5' (2024-10-27)
• Updated input 'ptitfred-posix-toolbox':
    'github:ptitfred/posix-toolbox/c1765143f3d8df604d5c04fdef78f62e98d7fbec' (2024-10-25)
  → 'github:ptitfred/posix-toolbox/658ff2ba30c4f760c2cb9d4e95c6e93e38c4ef56' (2024-10-29)
• Updated input 'ptitfred-posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/32e940c7c420600ef0d1ef396dc63b04ee9cad37' (2024-10-23)
  → 'github:nixos/nixpkgs/64b80bfb316b57cdb8919a9110ef63393d74382a' (2024-10-28)
```
