### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -362,11 +362,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1730537918,
-        "narHash": "sha256-GJB1/aaTnAtt9sso/EQ77TAGJ/rt6uvlP0RqZFnWue8=",
+        "lastModified": 1730886862,
+        "narHash": "sha256-wCZtRGM1NGxq6VG4+TMzfsa4cuG2VJVtowtYuWW5W3g=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "f6e0cd5c47d150c4718199084e5764f968f1b560",
+        "rev": "90642a0deae927fa911d49d4f7c5616257105141",
         "type": "github"
       },
       "original": {
@@ -409,11 +409,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1730327045,
-        "narHash": "sha256-xKel5kd1AbExymxoIfQ7pgcX6hjw9jCgbiBjiUfSVJ8=",
+        "lastModified": 1730741070,
+        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "080166c15633801df010977d9d7474b4a6c549d7",
+        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
         "type": "github"
       },
       "original": {
@@ -771,11 +771,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1728037102,
-        "narHash": "sha256-X685STJrIgMU6RGldl8CzV+Nwd0ncdS7vIBWHrv45xk=",
+        "lastModified": 1730784408,
+        "narHash": "sha256-ERpFr120bSfadYMnkNbNquppmF+Xrg9t/0xk87INq2A=",
         "owner": "wgsl-analyzer",
         "repo": "wgsl-analyzer",
-        "rev": "c5d7b3aefd1b8c6d0fe4d22b806cc9132a7fe6a5",
+        "rev": "a54d6a959518319655c1645d1212747e3b065e8a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'nixos-hardware':
    'github:nixos/nixos-hardware/f6e0cd5c47d150c4718199084e5764f968f1b560' (2024-11-02)
  → 'github:nixos/nixos-hardware/90642a0deae927fa911d49d4f7c5616257105141' (2024-11-06)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/080166c15633801df010977d9d7474b4a6c549d7' (2024-10-30)
  → 'github:nixos/nixpkgs/d063c1dd113c91ab27959ba540c0d9753409edf3' (2024-11-04)
• Updated input 'wgsl-analyzer':
    'github:wgsl-analyzer/wgsl-analyzer/c5d7b3aefd1b8c6d0fe4d22b806cc9132a7fe6a5' (2024-10-04)
  → 'github:wgsl-analyzer/wgsl-analyzer/a54d6a959518319655c1645d1212747e3b065e8a' (2024-11-05)
```
