### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -4,15 +4,16 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
+        "nix-github-actions": "nix-github-actions",
         "nixpkgs": "nixpkgs",
         "stable": "stable"
       },
       "locked": {
-        "lastModified": 1728263678,
-        "narHash": "sha256-gyUVsPAWY9AgVKjrNPoowrIr5BvK4gI0UkDXvv8iSxA=",
+        "lastModified": 1731249827,
+        "narHash": "sha256-04iOZoJ0D+y3xhZtaCgSBOz8T4hED7oMVkuAOzXT8vU=",
         "owner": "zhaofengli",
         "repo": "colmena",
-        "rev": "b0a62f234fae02a006123e661ff70e62af16106b",
+        "rev": "a2193487bcf70bbb998ad1a25a4ff02b8d55db7a",
         "type": "github"
       },
       "original": {
@@ -328,6 +329,27 @@
         "type": "github"
       }
     },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "colmena",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1729742964,
+        "narHash": "sha256-B4mzTcQ0FZHdpeWcpDYPERtyjJd/NIuaQ9+BV1h+MpA=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "e04df33f62cdcf93d73e9a04142464753a16db67",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
     "nixos-22_11": {
       "locked": {
         "lastModified": 1688392541,
@@ -362,11 +384,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1730886862,
-        "narHash": "sha256-wCZtRGM1NGxq6VG4+TMzfsa4cuG2VJVtowtYuWW5W3g=",
+        "lastModified": 1731403644,
+        "narHash": "sha256-T9V7CTucjRZ4Qc6pUEV/kpgNGzQbHWfGcfK6JJLfUeI=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "90642a0deae927fa911d49d4f7c5616257105141",
+        "rev": "f6581f1c3b137086e42a08a906bdada63045f991",
         "type": "github"
       },
       "original": {
@@ -377,11 +399,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725103162,
-        "narHash": "sha256-Ym04C5+qovuQDYL/rKWSR+WESseQBbNAe5DsXNx5trY=",
+        "lastModified": 1730785428,
+        "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "12228ff1752d7b7624a54e9c1af4b222b3c1073b",
+        "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
         "type": "github"
       },
       "original": {
@@ -409,11 +431,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1730741070,
-        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
+        "lastModified": 1731239293,
+        "narHash": "sha256-q2yjIWFFcTzp5REWQUOU9L6kHdCDmFDpqeix86SOvDc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
+        "rev": "9256f7c71a195ebe7a218043d9f93390d49e6884",
         "type": "github"
       },
       "original": {
@@ -441,11 +463,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1730327045,
-        "narHash": "sha256-xKel5kd1AbExymxoIfQ7pgcX6hjw9jCgbiBjiUfSVJ8=",
+        "lastModified": 1730741070,
+        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "080166c15633801df010977d9d7474b4a6c549d7",
+        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
         "type": "github"
       },
       "original": {
@@ -573,11 +595,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors_2"
       },
       "locked": {
-        "lastModified": 1730714793,
-        "narHash": "sha256-7rbUcQDvY231LaM1zgp6ciCAdnn8TibfMh9f55MVARo=",
+        "lastModified": 1730912555,
+        "narHash": "sha256-bdil2mbKDONFzq9MltLi/yh2JAY/MBKByLAmZz0wF5Y=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "a543d43898b6b6d69121630d96e0ad2df3853b86",
+        "rev": "9e55ac052a9c3758f53aa2c57019e8111349dcc0",
         "type": "github"
       },
       "original": {
@@ -643,11 +665,11 @@
     },
     "stable": {
       "locked": {
-        "lastModified": 1724316499,
-        "narHash": "sha256-Qb9MhKBUTCfWg/wqqaxt89Xfi6qTD3XpTzQ9eXi3JmE=",
+        "lastModified": 1730883749,
+        "narHash": "sha256-mwrFF0vElHJP8X3pFCByJR365Q2463ATp2qGIrDUdlE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "797f7dc49e0bc7fab4b57c021cdf68f595e47841",
+        "rev": "dba414932936fde69f0606b4f1d87c5bc0003ede",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'colmena':
    'github:zhaofengli/colmena/b0a62f234fae02a006123e661ff70e62af16106b' (2024-10-07)
  → 'github:zhaofengli/colmena/a2193487bcf70bbb998ad1a25a4ff02b8d55db7a' (2024-11-10)
• Added input 'colmena/nix-github-actions':
    'github:nix-community/nix-github-actions/e04df33f62cdcf93d73e9a04142464753a16db67' (2024-10-24)
• Added input 'colmena/nix-github-actions/nixpkgs':
    follows 'colmena/nixpkgs'
• Updated input 'colmena/nixpkgs':
    'github:NixOS/nixpkgs/12228ff1752d7b7624a54e9c1af4b222b3c1073b' (2024-08-31)
  → 'github:NixOS/nixpkgs/4aa36568d413aca0ea84a1684d2d46f55dbabad7' (2024-11-05)
• Updated input 'colmena/stable':
    'github:NixOS/nixpkgs/797f7dc49e0bc7fab4b57c021cdf68f595e47841' (2024-08-22)
  → 'github:NixOS/nixpkgs/dba414932936fde69f0606b4f1d87c5bc0003ede' (2024-11-06)
• Updated input 'nixos-hardware':
    'github:nixos/nixos-hardware/90642a0deae927fa911d49d4f7c5616257105141' (2024-11-06)
  → 'github:nixos/nixos-hardware/f6581f1c3b137086e42a08a906bdada63045f991' (2024-11-12)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/d063c1dd113c91ab27959ba540c0d9753409edf3' (2024-11-04)
  → 'github:nixos/nixpkgs/9256f7c71a195ebe7a218043d9f93390d49e6884' (2024-11-10)
• Updated input 'ptitfred-posix-toolbox':
    'github:ptitfred/posix-toolbox/a543d43898b6b6d69121630d96e0ad2df3853b86' (2024-11-04)
  → 'github:ptitfred/posix-toolbox/9e55ac052a9c3758f53aa2c57019e8111349dcc0' (2024-11-06)
• Updated input 'ptitfred-posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/080166c15633801df010977d9d7474b4a6c549d7' (2024-10-30)
  → 'github:nixos/nixpkgs/d063c1dd113c91ab27959ba540c0d9753409edf3' (2024-11-04)
```
