### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -316,11 +316,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1726716330,
-        "narHash": "sha256-mIuOP4I51eFLquRaxMKx67pHmhatZrcVPjfHL98v/M8=",
+        "lastModified": 1732053863,
+        "narHash": "sha256-DCIVdlb81Fct2uwzbtnawLBC/U03U2hqx8trqTJB7WA=",
         "owner": "oxalica",
         "repo": "nil",
-        "rev": "c8e8ce72442a164d89d3fdeaae0bcc405f8c015a",
+        "rev": "2e24c9834e3bb5aa2a3701d3713b43a6fb106362",
         "type": "github"
       },
       "original": {
@@ -415,11 +415,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1726481836,
-        "narHash": "sha256-MWTBH4dd5zIz2iatDb8IkqSjIeFum9jAqkFxgHLdzO4=",
+        "lastModified": 1731890469,
+        "narHash": "sha256-D1FNZ70NmQEwNxpSSdTXCSklBH1z2isPR84J6DQrJGs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "20f9370d5f588fb8c72e844c54511cab054b5f40",
+        "rev": "5083ec887760adfe12af64830a66807423a859a7",
         "type": "github"
       },
       "original": {
@@ -447,11 +447,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1731239293,
-        "narHash": "sha256-q2yjIWFFcTzp5REWQUOU9L6kHdCDmFDpqeix86SOvDc=",
+        "lastModified": 1731797254,
+        "narHash": "sha256-df3dJApLPhd11AlueuoN0Q4fHo/hagP75LlM5K1sz9g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9256f7c71a195ebe7a218043d9f93390d49e6884",
+        "rev": "e8c38b73aeb218e27163376a2d617e61a2ad9b59",
         "type": "github"
       },
       "original": {
@@ -501,11 +501,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1731407174,
-        "narHash": "sha256-9K7WAsPJVZbCeJoJltnFA1Olxc+uuC9YJKQNSN0Rsw8=",
+        "lastModified": 1731925134,
+        "narHash": "sha256-spEUZexvrIWGydujwFJX4fLAt6csr1dUVpR0Kf8CeFg=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "d981feee1fdba91c93b524c230f5ceb4b3c3ac1b",
+        "rev": "7f016c813e569effc75bd5537fde6bbd6c7cefa8",
         "type": "github"
       },
       "original": {
@@ -572,11 +572,11 @@
         "posix-toolbox": "posix-toolbox"
       },
       "locked": {
-        "lastModified": 1731515596,
-        "narHash": "sha256-d4e28RxtQu3eUSgfSEUDESwCkiX5Zaxo5XlVc9OOwCg=",
+        "lastModified": 1732119025,
+        "narHash": "sha256-RY9CIzM4dYEkmztiXatuP52wdAwkhpMbOdUN1r+aQd8=",
         "owner": "ptitfred",
         "repo": "personal-homepage",
-        "rev": "bb1a78387852c800f861654251edddbc824726f7",
+        "rev": "722cfcacadc65682e98338e8dda377f9958f9be8",
         "type": "github"
       },
       "original": {
@@ -634,11 +634,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726453838,
-        "narHash": "sha256-pupsow4L79SBfNwT6vh/5RAbVZuhngIA0RTCZksXmZY=",
+        "lastModified": 1731983527,
+        "narHash": "sha256-JECaBgC0pQ91Hq3W4unH6K9to8s2Zl2sPNu7bLOv4ek=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "ca2e79cd22625d214b8437c2c4080ce79bd9f7d2",
+        "rev": "71287228d96e9568e1e70c6bbfa3f992d145947b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'nil':
    'github:oxalica/nil/c8e8ce72442a164d89d3fdeaae0bcc405f8c015a' (2024-09-19)
  → 'github:oxalica/nil/2e24c9834e3bb5aa2a3701d3713b43a6fb106362' (2024-11-19)
• Updated input 'nil/flake-utils':
    'github:numtide/flake-utils/b1d9ab70662946ef0850d488da1c9019f3a9752a' (2024-03-11)
  → 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' (2024-11-13)
• Updated input 'nil/nixpkgs':
    'github:nixos/nixpkgs/20f9370d5f588fb8c72e844c54511cab054b5f40' (2024-09-16)
  → 'github:nixos/nixpkgs/5083ec887760adfe12af64830a66807423a859a7' (2024-11-18)
• Updated input 'nil/rust-overlay':
    'github:oxalica/rust-overlay/ca2e79cd22625d214b8437c2c4080ce79bd9f7d2' (2024-09-16)
  → 'github:oxalica/rust-overlay/71287228d96e9568e1e70c6bbfa3f992d145947b' (2024-11-19)
• Updated input 'ptitfred-personal-homepage':
    'github:ptitfred/personal-homepage/bb1a78387852c800f861654251edddbc824726f7' (2024-11-13)
  → 'github:ptitfred/personal-homepage/722cfcacadc65682e98338e8dda377f9958f9be8' (2024-11-20)
• Updated input 'ptitfred-personal-homepage/posix-toolbox':
    'github:ptitfred/posix-toolbox/d981feee1fdba91c93b524c230f5ceb4b3c3ac1b' (2024-11-12)
  → 'github:ptitfred/posix-toolbox/7f016c813e569effc75bd5537fde6bbd6c7cefa8' (2024-11-18)
• Updated input 'ptitfred-personal-homepage/posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/9256f7c71a195ebe7a218043d9f93390d49e6884' (2024-11-10)
  → 'github:nixos/nixpkgs/e8c38b73aeb218e27163376a2d617e61a2ad9b59' (2024-11-16)
```
