### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -384,11 +384,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1731797098,
-        "narHash": "sha256-UhWmEZhwJZmVZ1jfHZFzCg+ZLO9Tb/v3Y6LC0UNyeTo=",
+        "lastModified": 1732483221,
+        "narHash": "sha256-kF6rDeCshoCgmQz+7uiuPdREVFuzhIorGOoPXMalL2U=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "672ac2ac86f7dff2f6f3406405bddecf960e0db6",
+        "rev": "45348ad6fb8ac0e8415f6e5e96efe47dd7f39405",
         "type": "github"
       },
       "original": {
@@ -431,11 +431,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1731797254,
-        "narHash": "sha256-df3dJApLPhd11AlueuoN0Q4fHo/hagP75LlM5K1sz9g=",
+        "lastModified": 1733016324,
+        "narHash": "sha256-8qwPSE2g1othR1u4uP86NXxm6i7E9nHPyJX3m3lx7Q4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e8c38b73aeb218e27163376a2d617e61a2ad9b59",
+        "rev": "7e1ca67996afd8233d9033edd26e442836cc2ad6",
         "type": "github"
       },
       "original": {
@@ -793,11 +793,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1730784408,
-        "narHash": "sha256-ERpFr120bSfadYMnkNbNquppmF+Xrg9t/0xk87INq2A=",
+        "lastModified": 1732367608,
+        "narHash": "sha256-0iDIdDA/sTNanAzR50lVZ6v6LHs0rON6nj+1IaAjfsk=",
         "owner": "wgsl-analyzer",
         "repo": "wgsl-analyzer",
-        "rev": "a54d6a959518319655c1645d1212747e3b065e8a",
+        "rev": "5175e187b2d2ca33e8b50ddafb3ba4899473572b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'nixos-hardware':
    'github:nixos/nixos-hardware/672ac2ac86f7dff2f6f3406405bddecf960e0db6' (2024-11-16)
  → 'github:nixos/nixos-hardware/45348ad6fb8ac0e8415f6e5e96efe47dd7f39405' (2024-11-24)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e8c38b73aeb218e27163376a2d617e61a2ad9b59' (2024-11-16)
  → 'github:nixos/nixpkgs/7e1ca67996afd8233d9033edd26e442836cc2ad6' (2024-12-01)
• Updated input 'wgsl-analyzer':
    'github:wgsl-analyzer/wgsl-analyzer/a54d6a959518319655c1645d1212747e3b065e8a' (2024-11-05)
  → 'github:wgsl-analyzer/wgsl-analyzer/5175e187b2d2ca33e8b50ddafb3ba4899473572b' (2024-11-23)
```
