### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -260,16 +260,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1726989464,
-        "narHash": "sha256-Vl+WVTJwutXkimwGprnEtXc/s/s8sMuXzqXaspIGlwM=",
+        "lastModified": 1732466619,
+        "narHash": "sha256-T1e5oceypZu3Q8vzICjv1X/sGs9XfJRMW5OuXHgpB3c=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f23fa308a7c067e52dfcc30a0758f47043ec176",
+        "rev": "f3111f62a23451114433888902a55cf0692b408d",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-24.05",
+        "ref": "release-24.11",
         "repo": "home-manager",
         "type": "github"
       }
@@ -384,11 +384,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1732483221,
-        "narHash": "sha256-kF6rDeCshoCgmQz+7uiuPdREVFuzhIorGOoPXMalL2U=",
+        "lastModified": 1733481457,
+        "narHash": "sha256-IS3bxa4N1VMSh3/P6vhEAHQZecQ3oAlKCDvzCQSO5Is=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "45348ad6fb8ac0e8415f6e5e96efe47dd7f39405",
+        "rev": "e563803af3526852b6b1d77107a81908c66a9fcf",
         "type": "github"
       },
       "original": {
@@ -431,11 +431,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1733016324,
-        "narHash": "sha256-8qwPSE2g1othR1u4uP86NXxm6i7E9nHPyJX3m3lx7Q4=",
+        "lastModified": 1733384649,
+        "narHash": "sha256-K5DJ2LpPqht7K76bsxetI+YHhGGRyVteTPRQaIIKJpw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7e1ca67996afd8233d9033edd26e442836cc2ad6",
+        "rev": "190c31a89e5eec80dd6604d7f9e5af3802a58a13",
         "type": "github"
       },
       "original": {
@@ -447,32 +447,32 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1731797254,
-        "narHash": "sha256-df3dJApLPhd11AlueuoN0Q4fHo/hagP75LlM5K1sz9g=",
+        "lastModified": 1732981179,
+        "narHash": "sha256-F7thesZPvAMSwjRu0K8uFshTk3ZZSNAsXTIFvXBT+34=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e8c38b73aeb218e27163376a2d617e61a2ad9b59",
+        "rev": "62c435d93bf046a5396f3016472e8f7c8e2aed65",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1731797254,
-        "narHash": "sha256-df3dJApLPhd11AlueuoN0Q4fHo/hagP75LlM5K1sz9g=",
+        "lastModified": 1732981179,
+        "narHash": "sha256-F7thesZPvAMSwjRu0K8uFshTk3ZZSNAsXTIFvXBT+34=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e8c38b73aeb218e27163376a2d617e61a2ad9b59",
+        "rev": "62c435d93bf046a5396f3016472e8f7c8e2aed65",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -501,11 +501,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1731925134,
-        "narHash": "sha256-spEUZexvrIWGydujwFJX4fLAt6csr1dUVpR0Kf8CeFg=",
+        "lastModified": 1733156007,
+        "narHash": "sha256-y/JmdoNmN42ybqHMbBzGtQXgbnv1gxV/F3HnClnz0Ys=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "7f016c813e569effc75bd5537fde6bbd6c7cefa8",
+        "rev": "5b8e5187db506ee70a2120b15894a3f8d52233d8",
         "type": "github"
       },
       "original": {
@@ -572,11 +572,11 @@
         "posix-toolbox": "posix-toolbox"
       },
       "locked": {
-        "lastModified": 1732119025,
-        "narHash": "sha256-RY9CIzM4dYEkmztiXatuP52wdAwkhpMbOdUN1r+aQd8=",
+        "lastModified": 1733158482,
+        "narHash": "sha256-U4NtYeriV0u3C4QVFV335jIciE4nFuqao2452uGNaLw=",
         "owner": "ptitfred",
         "repo": "personal-homepage",
-        "rev": "722cfcacadc65682e98338e8dda377f9958f9be8",
+        "rev": "f3d33b2d09fbc647d8dcb772ef1ab1dcf70cf46e",
         "type": "github"
       },
       "original": {
@@ -595,11 +595,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors_2"
       },
       "locked": {
-        "lastModified": 1731925134,
-        "narHash": "sha256-spEUZexvrIWGydujwFJX4fLAt6csr1dUVpR0Kf8CeFg=",
+        "lastModified": 1733156007,
+        "narHash": "sha256-y/JmdoNmN42ybqHMbBzGtQXgbnv1gxV/F3HnClnz0Ys=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "7f016c813e569effc75bd5537fde6bbd6c7cefa8",
+        "rev": "5b8e5187db506ee70a2120b15894a3f8d52233d8",
         "type": "github"
       },
       "original": {
@@ -793,11 +793,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1732367608,
-        "narHash": "sha256-0iDIdDA/sTNanAzR50lVZ6v6LHs0rON6nj+1IaAjfsk=",
+        "lastModified": 1733233267,
+        "narHash": "sha256-FEwrLnUIQnMxhKQHN3czDvRknI3RxFb94rBbwxTHouE=",
         "owner": "wgsl-analyzer",
         "repo": "wgsl-analyzer",
-        "rev": "5175e187b2d2ca33e8b50ddafb3ba4899473572b",
+        "rev": "819805051f3407c2e328825f07389677711ba1e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'nixos-hardware':
    'github:nixos/nixos-hardware/45348ad6fb8ac0e8415f6e5e96efe47dd7f39405' (2024-11-24)
  → 'github:nixos/nixos-hardware/c6c90887f84c02ce9ebf33b95ca79ef45007bf88' (2024-12-02)
• Updated input 'ptitfred-personal-homepage':
    'github:ptitfred/personal-homepage/722cfcacadc65682e98338e8dda377f9958f9be8' (2024-11-20)
  → 'github:ptitfred/personal-homepage/f3d33b2d09fbc647d8dcb772ef1ab1dcf70cf46e' (2024-12-02)
• Updated input 'ptitfred-personal-homepage/posix-toolbox':
    'github:ptitfred/posix-toolbox/7f016c813e569effc75bd5537fde6bbd6c7cefa8' (2024-11-18)
  → 'github:ptitfred/posix-toolbox/5b8e5187db506ee70a2120b15894a3f8d52233d8' (2024-12-02)
• Updated input 'ptitfred-personal-homepage/posix-toolbox/home-manager':
    'github:nix-community/home-manager/2f23fa308a7c067e52dfcc30a0758f47043ec176' (2024-09-22)
  → 'github:nix-community/home-manager/f3111f62a23451114433888902a55cf0692b408d' (2024-11-24)
• Updated input 'ptitfred-personal-homepage/posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/e8c38b73aeb218e27163376a2d617e61a2ad9b59' (2024-11-16)
  → 'github:nixos/nixpkgs/62c435d93bf046a5396f3016472e8f7c8e2aed65' (2024-11-30)
• Updated input 'ptitfred-posix-toolbox':
    'github:ptitfred/posix-toolbox/7f016c813e569effc75bd5537fde6bbd6c7cefa8' (2024-11-18)
  → 'github:ptitfred/posix-toolbox/5b8e5187db506ee70a2120b15894a3f8d52233d8' (2024-12-02)
• Updated input 'ptitfred-posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/e8c38b73aeb218e27163376a2d617e61a2ad9b59' (2024-11-16)
  → 'github:nixos/nixpkgs/62c435d93bf046a5396f3016472e8f7c8e2aed65' (2024-11-30)
```
