### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -260,11 +260,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733572789,
-        "narHash": "sha256-zjO6m5BqxXIyjrnUziAzk4+T4VleqjstNudSqWcpsHI=",
+        "lastModified": 1733951536,
+        "narHash": "sha256-Zb5ZCa7Xj+0gy5XVXINTSr71fCfAv+IKtmIXNrykT54=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c7ffc9727d115e433fd884a62dc164b587ff651d",
+        "rev": "1318c3f3b068cdcea922fa7c1a0a1f0c96c22f5f",
         "type": "github"
       },
       "original": {
@@ -431,11 +431,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1734202038,
-        "narHash": "sha256-LwcGIkORU8zfQ/8jAgptgPY8Zf9lGKB0vtNdQyEkaN8=",
+        "lastModified": 1734529975,
+        "narHash": "sha256-ze3IJksru9dN0keqUxY0WNf8xrwfs8Ty/z9v/keyBbg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bcba2fbf6963bf6bed3a749f9f4cf5bff4adb96d",
+        "rev": "72d11d40b9878a67c38f003c240c2d2e1811e72a",
         "type": "github"
       },
       "original": {
@@ -447,11 +447,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1733550349,
-        "narHash": "sha256-NcGumB4Lr6KSDq+nIqXtNA8QwAQKDSZT7N9OTGWbTrs=",
+        "lastModified": 1733808091,
+        "narHash": "sha256-KWwINTQelKOoQgrXftxoqxmKFZb9pLVfnRvK270nkVk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e2605d0744c2417b09f8bf850dfca42fcf537d34",
+        "rev": "a0f3e10d94359665dba45b71b4227b0aeb851f8e",
         "type": "github"
       },
       "original": {
@@ -463,11 +463,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1733808091,
-        "narHash": "sha256-KWwINTQelKOoQgrXftxoqxmKFZb9pLVfnRvK270nkVk=",
+        "lastModified": 1734323986,
+        "narHash": "sha256-m/lh6hYMIWDYHCAsn81CDAiXoT3gmxXI9J987W5tZrE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a0f3e10d94359665dba45b71b4227b0aeb851f8e",
+        "rev": "394571358ce82dff7411395829aa6a3aad45b907",
         "type": "github"
       },
       "original": {
@@ -501,11 +501,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1733829714,
-        "narHash": "sha256-H1dXglbU7V3Ssg8C1MhVOonalNRJPHBQFjB61fFf+Wo=",
+        "lastModified": 1734023429,
+        "narHash": "sha256-Uzj0Rk65aiXRhyE+GTaoA0eU3oBGIUvg6MPsif1e3NQ=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "a9293f5737e6308bfcb13be81835f30ff59fd06b",
+        "rev": "a36c60610fc68d905aa610546fba9a16db9e62f3",
         "type": "github"
       },
       "original": {
@@ -572,11 +572,11 @@
         "posix-toolbox": "posix-toolbox"
       },
       "locked": {
-        "lastModified": 1734023438,
-        "narHash": "sha256-DXdiMwX+xlZZBD+dF6ehUBsY4I+Z2eDlDbnK/Zyo3go=",
+        "lastModified": 1734460839,
+        "narHash": "sha256-lyobNRrrgjJygjTPJwRBPJCFTX4Llh7qPUScLNRDhAA=",
         "owner": "ptitfred",
         "repo": "personal-homepage",
-        "rev": "b3859d28cfcdc6053cbc05c15a67111bc491c95a",
+        "rev": "8b1b11ed7edb746ec55258fb0e4a200b93622232",
         "type": "github"
       },
       "original": {
@@ -595,11 +595,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors_2"
       },
       "locked": {
-        "lastModified": 1734023429,
-        "narHash": "sha256-Uzj0Rk65aiXRhyE+GTaoA0eU3oBGIUvg6MPsif1e3NQ=",
+        "lastModified": 1734460827,
+        "narHash": "sha256-C5PkF7NyqoFMwzCI3I6oWquIrwoXs3Q/wurbvSAOw+U=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "a36c60610fc68d905aa610546fba9a16db9e62f3",
+        "rev": "53f70a51b00d78f1fea5e12af9a827bc1bab928a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/bcba2fbf6963bf6bed3a749f9f4cf5bff4adb96d' (2024-12-14)
  → 'github:nixos/nixpkgs/72d11d40b9878a67c38f003c240c2d2e1811e72a' (2024-12-18)
• Updated input 'ptitfred-personal-homepage':
    'github:ptitfred/personal-homepage/b3859d28cfcdc6053cbc05c15a67111bc491c95a' (2024-12-12)
  → 'github:ptitfred/personal-homepage/8b1b11ed7edb746ec55258fb0e4a200b93622232' (2024-12-17)
• Updated input 'ptitfred-personal-homepage/posix-toolbox':
    'github:ptitfred/posix-toolbox/a9293f5737e6308bfcb13be81835f30ff59fd06b' (2024-12-10)
  → 'github:ptitfred/posix-toolbox/a36c60610fc68d905aa610546fba9a16db9e62f3' (2024-12-12)
• Updated input 'ptitfred-personal-homepage/posix-toolbox/home-manager':
    'github:nix-community/home-manager/c7ffc9727d115e433fd884a62dc164b587ff651d' (2024-12-07)
  → 'github:nix-community/home-manager/1318c3f3b068cdcea922fa7c1a0a1f0c96c22f5f' (2024-12-11)
• Updated input 'ptitfred-personal-homepage/posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/e2605d0744c2417b09f8bf850dfca42fcf537d34' (2024-12-07)
  → 'github:nixos/nixpkgs/a0f3e10d94359665dba45b71b4227b0aeb851f8e' (2024-12-10)
• Updated input 'ptitfred-posix-toolbox':
    'github:ptitfred/posix-toolbox/a36c60610fc68d905aa610546fba9a16db9e62f3' (2024-12-12)
  → 'github:ptitfred/posix-toolbox/53f70a51b00d78f1fea5e12af9a827bc1bab928a' (2024-12-17)
• Updated input 'ptitfred-posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/a0f3e10d94359665dba45b71b4227b0aeb851f8e' (2024-12-10)
  → 'github:nixos/nixpkgs/394571358ce82dff7411395829aa6a3aad45b907' (2024-12-16)
```
