### PR TITLE
Finally fix puppeteer and homepage-screenshots.service

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -384,11 +384,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1734862644,
-        "narHash": "sha256-04xesW7HITdF5WUmNM39WD4tkEERk3Ez2W1nNvdIvIw=",
+        "lastModified": 1734954597,
+        "narHash": "sha256-QIhd8/0x30gEv8XEE1iAnrdMlKuQ0EzthfDR7Hwl+fk=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "e8516a23524cc9083f5a02a8d64d14770e4c7c09",
+        "rev": "def1d472c832d77885f174089b0d34854b007198",
         "type": "github"
       },
       "original": {
@@ -586,11 +586,11 @@
         "posix-toolbox": "posix-toolbox"
       },
       "locked": {
-        "lastModified": 1734911372,
-        "narHash": "sha256-sekQ9CZ9CpwRTdKxOx7TEHwtNyJR0ZnQwvnv3Jc1wR4=",
+        "lastModified": 1734959640,
+        "narHash": "sha256-7Nzdt9lpLDFUcQDPfQlGm87oq2atiLiT8izTa5GbJJc=",
         "owner": "ptitfred",
         "repo": "personal-homepage",
-        "rev": "d3a025d65b9d68a4f732a23c20ad6dc992937fc6",
+        "rev": "d5d14d367d47325fc7a72ff098870ab1f57b7c41",
         "type": "github"
       },
       "original": {

--- a/nixos/services/website.nix
+++ b/nixos/services/website.nix
@@ -148,6 +148,11 @@ in
           Group = "nginx";
           Type = "oneshot";
         };
+
+        environment = {
+          XDG_CONFIG_HOME = "/tmp/.chromium";
+          XDG_CACHE_HOME = "/tmp/.chromium";
+        };
       };
 
       systemd.timers.homepage-screenshots = mkIf cfg.screenshots {


### PR DESCRIPTION
- Shorter timeout for puppeteer to let the server do its business (https://github.com/ptitfred/personal-homepage/pull/85/commits/398cd2f975aa85ff09d9db34a626d9b3ed80afd4)
- Fix chromium configuration for headless servers (not needed for nixos tests though...) (https://github.com/puppeteer/puppeteer/issues/11023#issuecomment-1776247197).