### PR TITLE
Fix control chars leaking

### DIFF
--- a/home/desktop/theme.nix
+++ b/home/desktop/theme.nix
@@ -95,9 +95,9 @@ in
     xdg.configFile."gtk-3.0/colors.css".text = builtins.readFile ./colors.css;
 
     xresources.properties = with palette; {
-      "*.foreground"  = special.foreground;
-      "*.background"  = special.background;
-      "*.cursorColor" = special.cursorColor;
+      "URxvt*foreground"  = special.foreground;
+      "URxvt*background"  = special.background;
+      "URxvt*cursorColor" = special.cursorColor;
 
       "*.color0"  = mate.black;
       "*.color1"  = mate.red;

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -5,6 +5,7 @@ with final.lib.path;
 let load = directory:
       let version = builtins.fromJSON (builtins.readFile (append directory "version.json"));
        in overrides: final.callPackage (append directory "package.nix") (overrides // version);
+
  in {
       backgrounds = final.callPackage ./backgrounds {};
 
@@ -13,6 +14,8 @@ let load = directory:
       lix-updater      = final.callPackage ./lix-updater        {};
       matomo-updater   = final.callPackage matomo/updater.nix   {};
       obsidian-updater = final.callPackage obsidian/updater.nix {};
+
+      rxvt-unicode-emoji = final.callPackage ./rxvt-unicode-emoji { inherit (prev) rxvt-unicode-emoji; };
 
       matomo   = load ./matomo   {};
       obsidian = load ./obsidian { inherit (prev) obsidian; };

--- a/pkgs/rxvt-unicode-emoji/default.nix
+++ b/pkgs/rxvt-unicode-emoji/default.nix
@@ -1,0 +1,7 @@
+{ rxvt-unicode-emoji, rxvt-unicode-unwrapped-emoji }:
+
+let rxvt-unicode-unwrapped =
+      rxvt-unicode-unwrapped-emoji.overrideAttrs(_: previous:
+        { patches = [ ./fix-OSC-commands.patch ] ++ previous.patches; }
+      );
+ in rxvt-unicode-emoji.override { inherit rxvt-unicode-unwrapped; }

--- a/pkgs/rxvt-unicode-emoji/fix-OSC-commands.patch
+++ b/pkgs/rxvt-unicode-emoji/fix-OSC-commands.patch
@@ -1,0 +1,14 @@
+--- a/src/command.C
++++ b/src/command.C
+@@ -3426,9 +3426,9 @@ rxvt_term::process_color_seq (int report, int color, c
+         snprintf (rgba_str, sizeof (rgba_str), "rgb:%04x/%04x/%04x", c.r, c.g, c.b);
+ 
+       if (IN_RANGE_INC (color, minCOLOR, maxTermCOLOR))
+-        tt_printf ("\033]%d;%d;%s%c", report, color - minCOLOR, rgba_str, resp);
++        tt_printf ("\033]%d;%d;%s\033\\", report, color - minCOLOR, rgba_str);
+       else
+-        tt_printf ("\033]%d;%s%c", report, rgba_str, resp);
++        tt_printf ("\033]%d;%s\033\\", report, rgba_str, resp);
+     }
+   else
+     set_window_color (color, str);


### PR DESCRIPTION
urxvt has introduced a sneaky bug causing tmux to leak some unexpected characters (background and foreground colors).

Looks like nobody feels that bad about it to properly fix it. I found a working patch from [this conversation](https://bbs.archlinux.org/viewtopic.php?id=293022).