### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -431,11 +431,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1735531152,
-        "narHash": "sha256-As8I+ebItDKtboWgDXYZSIjGlKeqiLBvjxsQHUmAf1Q=",
+        "lastModified": 1735669367,
+        "narHash": "sha256-tfYRbFhMOnYaM4ippqqid3BaLOXoFNdImrfBfCp4zn0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3ffbbdbac0566a0977da3d2657b89cbcfe9a173b",
+        "rev": "edf04b75c13c2ac0e54df5ec5c543e300f76f1c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/3ffbbdbac0566a0977da3d2657b89cbcfe9a173b' (2024-12-30)
  → 'github:nixos/nixpkgs/edf04b75c13c2ac0e54df5ec5c543e300f76f1c9' (2024-12-31)
```
