### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -431,6 +431,22 @@
     },
     "nixpkgs_3": {
       "locked": {
+        "lastModified": 1736061677,
+        "narHash": "sha256-DjkQPnkAfd7eB522PwnkGhOMuT9QVCZspDpJJYyOj60=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "cbd8ec4de4469333c82ff40d057350c30e9f7d36",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
         "lastModified": 1735669367,
         "narHash": "sha256-tfYRbFhMOnYaM4ippqqid3BaLOXoFNdImrfBfCp4zn0=",
         "owner": "nixos",
@@ -445,29 +461,13 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1734875076,
         "narHash": "sha256-Pzyb+YNG5u3zP79zoi8HXYMs15Q5dfjDgwCdUI5B0nY=",
         "owner": "nixos",
         "repo": "nixpkgs",
         "rev": "1807c2b91223227ad5599d7067a61665c52d1295",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-24.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_5": {
-      "locked": {
-        "lastModified": 1734323986,
-        "narHash": "sha256-m/lh6hYMIWDYHCAsn81CDAiXoT3gmxXI9J987W5tZrE=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "394571358ce82dff7411395829aa6a3aad45b907",
         "type": "github"
       },
       "original": {
@@ -479,11 +479,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1734875076,
-        "narHash": "sha256-Pzyb+YNG5u3zP79zoi8HXYMs15Q5dfjDgwCdUI5B0nY=",
+        "lastModified": 1735669367,
+        "narHash": "sha256-tfYRbFhMOnYaM4ippqqid3BaLOXoFNdImrfBfCp4zn0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1807c2b91223227ad5599d7067a61665c52d1295",
+        "rev": "edf04b75c13c2ac0e54df5ec5c543e300f76f1c9",
         "type": "github"
       },
       "original": {
@@ -517,11 +517,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1734460827,
-        "narHash": "sha256-C5PkF7NyqoFMwzCI3I6oWquIrwoXs3Q/wurbvSAOw+U=",
+        "lastModified": 1734976399,
+        "narHash": "sha256-vFIb8zQNt4k/+rKkX9CObFysyd/z+/sjhUTTCEvkqXQ=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "53f70a51b00d78f1fea5e12af9a827bc1bab928a",
+        "rev": "0fcee67de66e1992c9e517fcf4ca16df5e61341e",
         "type": "github"
       },
       "original": {
@@ -586,11 +586,11 @@
         "posix-toolbox": "posix-toolbox"
       },
       "locked": {
-        "lastModified": 1735508704,
-        "narHash": "sha256-HxVQfMIta7fsOywx9SJ3Z5fE/Waq5MzMDuN+77f+Ufg=",
+        "lastModified": 1736154298,
+        "narHash": "sha256-byuza3rzIXXO49qXAIw+d2sLTjjks0Zn1UrAdJ35CSA=",
         "owner": "ptitfred",
         "repo": "personal-homepage",
-        "rev": "b9a0cc8ec21ab756fa44e6fa9ccccc2877a3f99a",
+        "rev": "bb2aff3a8c3edb8c540758f21dd30aadda6731ec",
         "type": "github"
       },
       "original": {
@@ -609,11 +609,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors_2"
       },
       "locked": {
-        "lastModified": 1734976399,
-        "narHash": "sha256-vFIb8zQNt4k/+rKkX9CObFysyd/z+/sjhUTTCEvkqXQ=",
+        "lastModified": 1736154310,
+        "narHash": "sha256-WwylutYs+jjjSa/tksgRDlfgwbrdEkjhICj0Ycdk+8Y=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "0fcee67de66e1992c9e517fcf4ca16df5e61341e",
+        "rev": "1301da3b26c1040b846abb9776702d7057c1fa21",
         "type": "github"
       },
       "original": {
@@ -771,11 +771,11 @@
     "trapd00r-ls-colors": {
       "flake": false,
       "locked": {
-        "lastModified": 1723826680,
-        "narHash": "sha256-/l4LpOBHPvfg6kmLvK96b5pOjEk9wh5QwfH79h5aVpw=",
+        "lastModified": 1734720078,
+        "narHash": "sha256-ePs7UlgQqh3ptRXUNlY/BDa/1aH9q3dGa3h0or/e6Kk=",
         "owner": "trapd00r",
         "repo": "LS_COLORS",
-        "rev": "20cc87c21f5f54cf86be7e5867af9efc65b8b4e3",
+        "rev": "81e2ebcdc2ed815d17db962055645ccf2125560c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/edf04b75c13c2ac0e54df5ec5c543e300f76f1c9' (2024-12-31)
  → 'github:nixos/nixpkgs/cbd8ec4de4469333c82ff40d057350c30e9f7d36' (2025-01-05)
• Updated input 'ptitfred-personal-homepage':
    'github:ptitfred/personal-homepage/b9a0cc8ec21ab756fa44e6fa9ccccc2877a3f99a' (2024-12-29)
  → 'github:ptitfred/personal-homepage/bb2aff3a8c3edb8c540758f21dd30aadda6731ec' (2025-01-06)
• Updated input 'ptitfred-personal-homepage/nixpkgs':
    'github:nixos/nixpkgs/1807c2b91223227ad5599d7067a61665c52d1295' (2024-12-22)
  → 'github:nixos/nixpkgs/edf04b75c13c2ac0e54df5ec5c543e300f76f1c9' (2024-12-31)
• Updated input 'ptitfred-personal-homepage/posix-toolbox':
    'github:ptitfred/posix-toolbox/53f70a51b00d78f1fea5e12af9a827bc1bab928a' (2024-12-17)
  → 'github:ptitfred/posix-toolbox/0fcee67de66e1992c9e517fcf4ca16df5e61341e' (2024-12-23)
• Updated input 'ptitfred-personal-homepage/posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/394571358ce82dff7411395829aa6a3aad45b907' (2024-12-16)
  → 'github:nixos/nixpkgs/1807c2b91223227ad5599d7067a61665c52d1295' (2024-12-22)
• Updated input 'ptitfred-personal-homepage/posix-toolbox/trapd00r-ls-colors':
    'github:trapd00r/LS_COLORS/20cc87c21f5f54cf86be7e5867af9efc65b8b4e3' (2024-08-16)
  → 'github:trapd00r/LS_COLORS/81e2ebcdc2ed815d17db962055645ccf2125560c' (2024-12-20)
• Updated input 'ptitfred-posix-toolbox':
    'github:ptitfred/posix-toolbox/0fcee67de66e1992c9e517fcf4ca16df5e61341e' (2024-12-23)
  → 'github:ptitfred/posix-toolbox/1301da3b26c1040b846abb9776702d7057c1fa21' (2025-01-06)
• Updated input 'ptitfred-posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/1807c2b91223227ad5599d7067a61665c52d1295' (2024-12-22)
  → 'github:nixos/nixpkgs/edf04b75c13c2ac0e54df5ec5c543e300f76f1c9' (2024-12-31)
```
