### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -237,11 +237,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735344290,
-        "narHash": "sha256-oJDtWPH1oJT34RJK1FSWjwX4qcGOBRkcNQPD0EbSfNM=",
+        "lastModified": 1736373539,
+        "narHash": "sha256-dinzAqCjenWDxuy+MqUQq0I4zUSfaCvN9rzuCmgMZJY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "613691f285dad87694c2ba1c9e6298d04736292d",
+        "rev": "bd65bc3cde04c16755955630b344bc9e35272c56",
         "type": "github"
       },
       "original": {
@@ -260,11 +260,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734366194,
-        "narHash": "sha256-vykpJ1xsdkv0j8WOVXrRFHUAdp9NXHpxdnn1F4pYgSw=",
+        "lastModified": 1735344290,
+        "narHash": "sha256-oJDtWPH1oJT34RJK1FSWjwX4qcGOBRkcNQPD0EbSfNM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "80b0fdf483c5d1cb75aaad909bd390d48673857f",
+        "rev": "613691f285dad87694c2ba1c9e6298d04736292d",
         "type": "github"
       },
       "original": {
@@ -384,11 +384,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1735388221,
-        "narHash": "sha256-e5IOgjQf0SZcFCEV/gMGrsI0gCJyqOKShBQU0iiM3Kg=",
+        "lastModified": 1736441705,
+        "narHash": "sha256-OL7leZ6KBhcDF3nEKe4aZVfIm6xQpb1Kb+mxySIP93o=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "7c674c6734f61157e321db595dbfcd8523e04e19",
+        "rev": "8870dcaff63dfc6647fb10648b827e9d40b0a337",
         "type": "github"
       },
       "original": {
@@ -431,6 +431,38 @@
     },
     "nixpkgs_3": {
       "locked": {
+        "lastModified": 1736684107,
+        "narHash": "sha256-vH5mXxEvZeoGNkqKoCluhTGfoeXCZ1seYhC2pbMN0sg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "635e887b48521e912a516625eee7df6cf0eba9c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1736684107,
+        "narHash": "sha256-vH5mXxEvZeoGNkqKoCluhTGfoeXCZ1seYhC2pbMN0sg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "635e887b48521e912a516625eee7df6cf0eba9c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
         "lastModified": 1736061677,
         "narHash": "sha256-DjkQPnkAfd7eB522PwnkGhOMuT9QVCZspDpJJYyOj60=",
         "owner": "nixos",
@@ -445,45 +477,13 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1735669367,
-        "narHash": "sha256-tfYRbFhMOnYaM4ippqqid3BaLOXoFNdImrfBfCp4zn0=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "edf04b75c13c2ac0e54df5ec5c543e300f76f1c9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-24.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_5": {
-      "locked": {
-        "lastModified": 1734875076,
-        "narHash": "sha256-Pzyb+YNG5u3zP79zoi8HXYMs15Q5dfjDgwCdUI5B0nY=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "1807c2b91223227ad5599d7067a61665c52d1295",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-24.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1735669367,
-        "narHash": "sha256-tfYRbFhMOnYaM4ippqqid3BaLOXoFNdImrfBfCp4zn0=",
+        "lastModified": 1736684107,
+        "narHash": "sha256-vH5mXxEvZeoGNkqKoCluhTGfoeXCZ1seYhC2pbMN0sg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "edf04b75c13c2ac0e54df5ec5c543e300f76f1c9",
+        "rev": "635e887b48521e912a516625eee7df6cf0eba9c1",
         "type": "github"
       },
       "original": {
@@ -517,11 +517,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1734976399,
-        "narHash": "sha256-vFIb8zQNt4k/+rKkX9CObFysyd/z+/sjhUTTCEvkqXQ=",
+        "lastModified": 1736207241,
+        "narHash": "sha256-L9AsWOVEkpW01OKHRvhdc05fgtlPShjJc5BNnaXAtWE=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "0fcee67de66e1992c9e517fcf4ca16df5e61341e",
+        "rev": "d01dd5e7e1c4c99a412a525f2e77e82022f3a0ff",
         "type": "github"
       },
       "original": {
@@ -586,11 +586,11 @@
         "posix-toolbox": "posix-toolbox"
       },
       "locked": {
-        "lastModified": 1736154298,
-        "narHash": "sha256-byuza3rzIXXO49qXAIw+d2sLTjjks0Zn1UrAdJ35CSA=",
+        "lastModified": 1736785448,
+        "narHash": "sha256-b656CYbqA0yOet2uBeBH6wi4wxVcSJhymoSnFlcL9sU=",
         "owner": "ptitfred",
         "repo": "personal-homepage",
-        "rev": "bb2aff3a8c3edb8c540758f21dd30aadda6731ec",
+        "rev": "fb7ef3a8f793eee9031fb23fce9a8202361a1e94",
         "type": "github"
       },
       "original": {
@@ -609,11 +609,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors_2"
       },
       "locked": {
-        "lastModified": 1736154310,
-        "narHash": "sha256-WwylutYs+jjjSa/tksgRDlfgwbrdEkjhICj0Ycdk+8Y=",
+        "lastModified": 1736785435,
+        "narHash": "sha256-wY4rDL+4Xm3sRKzvk4CDKvRwBuHvvBuvm7aYEUv0a4Y=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "1301da3b26c1040b846abb9776702d7057c1fa21",
+        "rev": "8ce6a22adc8e09c65c81198da86bd18b49263e37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'home-manager':
    'github:nix-community/home-manager/613691f285dad87694c2ba1c9e6298d04736292d' (2024-12-28)
  → 'github:nix-community/home-manager/bd65bc3cde04c16755955630b344bc9e35272c56' (2025-01-08)
• Updated input 'nixos-hardware':
    'github:nixos/nixos-hardware/7c674c6734f61157e321db595dbfcd8523e04e19' (2024-12-28)
  → 'github:nixos/nixos-hardware/8870dcaff63dfc6647fb10648b827e9d40b0a337' (2025-01-09)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/cbd8ec4de4469333c82ff40d057350c30e9f7d36' (2025-01-05)
  → 'github:nixos/nixpkgs/635e887b48521e912a516625eee7df6cf0eba9c1' (2025-01-12)
• Updated input 'ptitfred-personal-homepage':
    'github:ptitfred/personal-homepage/bb2aff3a8c3edb8c540758f21dd30aadda6731ec' (2025-01-06)
  → 'github:ptitfred/personal-homepage/fb7ef3a8f793eee9031fb23fce9a8202361a1e94' (2025-01-13)
• Updated input 'ptitfred-personal-homepage/nixpkgs':
    'github:nixos/nixpkgs/edf04b75c13c2ac0e54df5ec5c543e300f76f1c9' (2024-12-31)
  → 'github:nixos/nixpkgs/635e887b48521e912a516625eee7df6cf0eba9c1' (2025-01-12)
• Updated input 'ptitfred-personal-homepage/posix-toolbox':
    'github:ptitfred/posix-toolbox/0fcee67de66e1992c9e517fcf4ca16df5e61341e' (2024-12-23)
  → 'github:ptitfred/posix-toolbox/d01dd5e7e1c4c99a412a525f2e77e82022f3a0ff' (2025-01-06)
• Updated input 'ptitfred-personal-homepage/posix-toolbox/home-manager':
    'github:nix-community/home-manager/80b0fdf483c5d1cb75aaad909bd390d48673857f' (2024-12-16)
  → 'github:nix-community/home-manager/613691f285dad87694c2ba1c9e6298d04736292d' (2024-12-28)
• Updated input 'ptitfred-personal-homepage/posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/1807c2b91223227ad5599d7067a61665c52d1295' (2024-12-22)
  → 'github:nixos/nixpkgs/cbd8ec4de4469333c82ff40d057350c30e9f7d36' (2025-01-05)
• Updated input 'ptitfred-posix-toolbox':
    'github:ptitfred/posix-toolbox/1301da3b26c1040b846abb9776702d7057c1fa21' (2025-01-06)
  → 'github:ptitfred/posix-toolbox/8ce6a22adc8e09c65c81198da86bd18b49263e37' (2025-01-13)
• Updated input 'ptitfred-posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/edf04b75c13c2ac0e54df5ec5c543e300f76f1c9' (2024-12-31)
  → 'github:nixos/nixpkgs/635e887b48521e912a516625eee7df6cf0eba9c1' (2025-01-12)
```
