### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -384,11 +384,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1737751639,
-        "narHash": "sha256-ZEbOJ9iT72iwqXsiEMbEa8wWjyFvRA9Ugx8utmYbpz4=",
+        "lastModified": 1738471961,
+        "narHash": "sha256-cgXDFrplNGs7bCVzXhRofjD8oJYqqXGcmUzXjHmip6Y=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "dfad538f751a5aa5d4436d9781ab27a6128ec9d4",
+        "rev": "537286c3c59b40311e5418a180b38034661d2536",
         "type": "github"
       },
       "original": {
@@ -431,11 +431,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1738163270,
-        "narHash": "sha256-B/7Y1v4y+msFFBW1JAdFjNvVthvNdJKiN6EGRPnqfno=",
+        "lastModified": 1738435198,
+        "narHash": "sha256-5+Hmo4nbqw8FrW85FlNm4IIrRnZ7bn0cmXlScNsNRLo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "59e618d90c065f55ae48446f307e8c09565d5ab0",
+        "rev": "f6687779bf4c396250831aa5a32cbfeb85bb07a3",
         "type": "github"
       },
       "original": {
@@ -479,11 +479,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1737672001,
-        "narHash": "sha256-YnHJJ19wqmibLQdUeq9xzE6CjrMA568KN/lFPuSVs4I=",
+        "lastModified": 1738163270,
+        "narHash": "sha256-B/7Y1v4y+msFFBW1JAdFjNvVthvNdJKiN6EGRPnqfno=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "035f8c0853c2977b24ffc4d0a42c74f00b182cd8",
+        "rev": "59e618d90c065f55ae48446f307e8c09565d5ab0",
         "type": "github"
       },
       "original": {
@@ -609,11 +609,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors_2"
       },
       "locked": {
-        "lastModified": 1737970022,
-        "narHash": "sha256-YX3D8xOZzGCZOrkqOXQBFXYeH9PEL3dvmdPmMFl+4I8=",
+        "lastModified": 1738256708,
+        "narHash": "sha256-etjHRHtHSwMsFOyApjcpMpYsBVnzWSRzUYsaRv6nw/g=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "75bc5109f4d32941da0d1ad792fb721deb9e545f",
+        "rev": "7f06451718388e12d1a39021e37f604fa2076ad8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'nixos-hardware':
    'github:nixos/nixos-hardware/dfad538f751a5aa5d4436d9781ab27a6128ec9d4' (2025-01-24)
  → 'github:nixos/nixos-hardware/537286c3c59b40311e5418a180b38034661d2536' (2025-02-02)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/59e618d90c065f55ae48446f307e8c09565d5ab0' (2025-01-29)
  → 'github:nixos/nixpkgs/f6687779bf4c396250831aa5a32cbfeb85bb07a3' (2025-02-01)
• Updated input 'ptitfred-posix-toolbox':
    'github:ptitfred/posix-toolbox/75bc5109f4d32941da0d1ad792fb721deb9e545f' (2025-01-27)
  → 'github:ptitfred/posix-toolbox/7f06451718388e12d1a39021e37f604fa2076ad8' (2025-01-30)
• Updated input 'ptitfred-posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/035f8c0853c2977b24ffc4d0a42c74f00b182cd8' (2025-01-23)
  → 'github:nixos/nixpkgs/59e618d90c065f55ae48446f307e8c09565d5ab0' (2025-01-29)
```
